### PR TITLE
Harden payment ledger integrity (G2)

### DIFF
--- a/src/Ombor.Application/Extensions/PaymentCalculationExtensions.cs
+++ b/src/Ombor.Application/Extensions/PaymentCalculationExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Ombor.Application.Interfaces;
+using Ombor.Domain.Entities;
 using Ombor.Domain.Enums;
 
 namespace Ombor.Application.Extensions;
@@ -36,5 +37,37 @@ internal static class PaymentCalculationExtensions
         var count = await context.Payments.CountAsync();
 
         return $"P-{count + 1}";
+    }
+
+    /// <summary>
+    /// Persists a newly added payment, minting its sequential number and retrying if a concurrent
+    /// create claimed the same value. The number is the dispute trail's human handle and is guarded by a
+    /// unique index on (OrganizationId, Number); a race must never surface as a duplicate or a 500.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately runs without an explicit transaction: one <see cref="IApplicationDbContext.SaveChangesAsync"/>
+    /// is already atomic, so a failed attempt fully rolls back before the next number is minted. Wrapping this
+    /// in a manual transaction would replay partially-applied statements on retry.
+    /// </remarks>
+    public static async Task SaveWithPaymentNumberAsync(this IApplicationDbContext context, Payment payment)
+    {
+        ArgumentNullException.ThrowIfNull(payment);
+
+        const int maxAttempts = 5;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            payment.Number = await context.NextPaymentNumberAsync();
+
+            try
+            {
+                await context.SaveChangesAsync();
+                return;
+            }
+            catch (DbUpdateException) when (attempt < maxAttempts)
+            {
+                // A concurrent payment claimed this number; re-mint against the now-committed count and retry.
+            }
+        }
     }
 }

--- a/src/Ombor.Application/Services/PaymentService.cs
+++ b/src/Ombor.Application/Services/PaymentService.cs
@@ -49,22 +49,35 @@ internal sealed class PaymentService(
             .Where(t => settledIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id);
 
-        foreach (var settlement in settlements)
+        if (settlements.Any(s => s.Amount <= 0))
         {
-            if (settlement.Amount <= 0)
+            throw new ValidationException("Settlement amount must be greater than zero.");
+        }
+
+        // Collapse duplicate rows per transaction so a repeated TransactionId can't overpay or double-apply.
+        var settlementsByTransaction = settlements
+            .GroupBy(s => s.TransactionId)
+            .ToDictionary(g => g.Key, g => g.Sum(s => s.Amount));
+
+        foreach (var (transactionId, amount) in settlementsByTransaction)
+        {
+            if (!transactions.TryGetValue(transactionId, out var transaction))
             {
-                throw new ValidationException("Settlement amount must be greater than zero.");
+                throw new EntityNotFoundException<TransactionRecord>(transactionId);
             }
 
-            if (!transactions.TryGetValue(settlement.TransactionId, out var transaction))
-            {
-                throw new EntityNotFoundException<TransactionRecord>(settlement.TransactionId);
-            }
-
-            if (settlement.Amount > transaction.UnpaidAmount)
+            // A payment may only settle its own partner's transactions; otherwise partner A settles
+            // partner B's debt and both ledgers corrupt.
+            if (transaction.PartnerId != request.PartnerId)
             {
                 throw new ValidationException(
-                    $"Settlement of {settlement.Amount} exceeds the remaining {transaction.UnpaidAmount} on transaction {transaction.Id}.");
+                    $"Transaction {transactionId} does not belong to partner {request.PartnerId}.");
+            }
+
+            if (amount > transaction.UnpaidAmount)
+            {
+                throw new ValidationException(
+                    $"Settlement of {amount} exceeds the remaining {transaction.UnpaidAmount} on transaction {transaction.Id}.");
             }
         }
 
@@ -85,7 +98,6 @@ internal sealed class PaymentService(
 
         var payment = new Payment
         {
-            Number = await context.NextPaymentNumberAsync(),
             Type = request.Type.ToDomainType(),
             Direction = request.Direction.ToDomainDirection(),
             DateUtc = DateTimeOffset.UtcNow,
@@ -105,17 +117,17 @@ internal sealed class PaymentService(
         });
 
         // Settling allocations (rule 10): one per settled transaction, plus any excess parked as advance.
-        foreach (var settlement in settlements)
+        foreach (var (transactionId, amount) in settlementsByTransaction)
         {
             payment.Allocations.Add(new PaymentAllocation
             {
                 Payment = payment,
-                TransactionId = settlement.TransactionId,
+                TransactionId = transactionId,
                 Type = PaymentAllocationType.TransactionSettlement,
-                Amount = settlement.Amount,
+                Amount = amount,
             });
 
-            transactions[settlement.TransactionId].AddPayment(settlement.Amount);
+            transactions[transactionId].AddPayment(amount);
         }
 
         if (advanceAmount > 0 && request.PartnerId is not null)
@@ -129,7 +141,7 @@ internal sealed class PaymentService(
         }
 
         context.Payments.Add(payment);
-        await context.SaveChangesAsync();
+        await context.SaveWithPaymentNumberAsync(payment);
 
         return await GetRecordByIdAsync(payment.Id);
     }
@@ -301,7 +313,6 @@ internal sealed class PaymentService(
 
         var payment = new Payment
         {
-            Number = await context.NextPaymentNumberAsync(),
             Type = PaymentType.Payroll,
             Direction = PaymentDirection.Expense,
             DateUtc = DateTimeOffset.UtcNow,
@@ -322,7 +333,7 @@ internal sealed class PaymentService(
         });
 
         context.Payments.Add(payment);
-        await context.SaveChangesAsync();
+        await context.SaveWithPaymentNumberAsync(payment);
 
         return await GetRecordByIdAsync(payment.Id);
     }

--- a/src/Ombor.Application/Services/TransactionService.cs
+++ b/src/Ombor.Application/Services/TransactionService.cs
@@ -257,6 +257,10 @@ internal sealed class TransactionService(
             }
         }
 
+        // Minted eagerly here rather than via the retry helper: this runs inside the create's explicit
+        // transaction (stock + money atomicity), where re-saving after a collision would replay the
+        // AddPayment updates. The unique (OrganizationId, Number) index still guarantees no duplicate — a
+        // rare concurrent collision rolls the whole transaction back cleanly.
         var payment = new Payment
         {
             Number = await context.NextPaymentNumberAsync(),
@@ -286,17 +290,22 @@ internal sealed class TransactionService(
                 .Where(t => settledIds.Contains(t.Id))
                 .ToDictionaryAsync(t => t.Id);
 
-            foreach (var settlement in settlements)
+            // One settling allocation per transaction; duplicate rows are summed (validated in ValidateOrThrowAsync).
+            var settlementsByTransaction = settlements
+                .GroupBy(s => s.TransactionId)
+                .ToDictionary(g => g.Key, g => g.Sum(s => s.Amount));
+
+            foreach (var (transactionId, amount) in settlementsByTransaction)
             {
-                var settled = settledTransactions[settlement.TransactionId];
+                var settled = settledTransactions[transactionId];
                 payment.Allocations.Add(new PaymentAllocation
                 {
                     Payment = payment,
-                    TransactionId = settlement.TransactionId,
+                    TransactionId = transactionId,
                     Type = PaymentAllocationType.TransactionSettlement,
-                    Amount = settlement.Amount,
+                    Amount = amount,
                 });
-                settled.AddPayment(settlement.Amount);
+                settled.AddPayment(amount);
             }
         }
 
@@ -387,22 +396,27 @@ internal sealed class TransactionService(
             .Where(t => settledIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id);
 
-        foreach (var settlement in settlements)
+        // Collapse duplicate rows per transaction so a repeated TransactionId can't overpay (or 500 on apply).
+        var settlementsByTransaction = settlements
+            .GroupBy(s => s.TransactionId)
+            .ToDictionary(g => g.Key, g => g.Sum(s => s.Amount));
+
+        foreach (var (transactionId, amount) in settlementsByTransaction)
         {
-            if (!settledTransactions.TryGetValue(settlement.TransactionId, out var settled))
+            if (!settledTransactions.TryGetValue(transactionId, out var settled))
             {
-                throw new ValidationException($"Transaction {settlement.TransactionId} does not exist.");
+                throw new ValidationException($"Transaction {transactionId} does not exist.");
             }
 
             if (settled.PartnerId != request.PartnerId)
             {
-                throw new ValidationException($"Transaction {settlement.TransactionId} does not belong to partner {request.PartnerId}.");
+                throw new ValidationException($"Transaction {transactionId} does not belong to partner {request.PartnerId}.");
             }
 
-            if (settlement.Amount > settled.UnpaidAmount)
+            if (amount > settled.UnpaidAmount)
             {
                 throw new ValidationException(
-                    $"Settlement of {settlement.Amount} exceeds the remaining {settled.UnpaidAmount} on transaction {settled.Id}.");
+                    $"Settlement of {amount} exceeds the remaining {settled.UnpaidAmount} on transaction {settled.Id}.");
             }
         }
     }

--- a/src/Ombor.Infrastructure/Persistence/Configurations/PaymentConfiguration.cs
+++ b/src/Ombor.Infrastructure/Persistence/Configurations/PaymentConfiguration.cs
@@ -53,6 +53,13 @@ internal sealed class PaymentConfiguration : IEntityTypeConfiguration<Payment>
             .HasMaxLength(ConfigurationConstants.EnumLength)
             .IsRequired(false);
 
+        // The payment number is the dispute trail's human handle: unique per organization so concurrent
+        // creates can't mint the same «P-n» (filtered to skip the nullable column's single-NULL rule).
+        builder
+            .HasIndex(p => new { p.OrganizationId, p.Number })
+            .IsUnique()
+            .HasFilter("[Number] IS NOT NULL");
+
         builder
             .Property(p => p.Notes)
             .HasMaxLength(ConfigurationConstants.MaxStringLength)

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260714140133_Add_Payment_Number_Unique_Index.Designer.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260714140133_Add_Payment_Number_Unique_Index.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombor.Infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using Ombor.Infrastructure.Persistence;
 namespace Ombor.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714140133_Add_Payment_Number_Unique_Index")]
+    partial class Add_Payment_Number_Unique_Index
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260714140133_Add_Payment_Number_Unique_Index.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260714140133_Add_Payment_Number_Unique_Index.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombor.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Payment_Number_Unique_Index : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Payment_OrganizationId_Number",
+                table: "Payment",
+                columns: new[] { "OrganizationId", "Number" },
+                unique: true,
+                filter: "[Number] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Payment_OrganizationId_Number",
+                table: "Payment");
+        }
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PaymentLedgerIntegrityTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PaymentLedgerIntegrityTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Payment;
+using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.PaymentEndpoints;
+
+/// <summary>
+/// Guards on the dispute-grade payment ledger: a payment may only settle its own partner's transactions,
+/// duplicate settlement rows can't overpay or crash, and the human payment number stays unique.
+/// </summary>
+public sealed class PaymentLedgerIntegrityTests(TestingWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : PaymentTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task PostAsync_ShouldReject_WhenSettlingAnotherPartnersTransaction()
+    {
+        // Arrange — partner B owes on a sale; partner A tries to settle it (would corrupt both ledgers).
+        var walletId = await CreateWalletAsync(0m);
+        var partnerAId = await CreatePartnerAsync();
+        var partnerBId = await CreatePartnerAsync();
+        var partnerBSaleId = await CreateOpenSaleAsync(partnerBId, total: 10_000m);
+
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.Transaction, PaymentDirection.Income, partnerAId, null, walletId,
+            Amount: 10_000m, Description: null, Period: null,
+            Settlements: [new SettlementInput(partnerBSaleId, 10_000m)]);
+
+        // Act & Assert — a clean 400, and partner B's sale is untouched.
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+
+        var sale = await _context.Transactions.AsNoTracking().FirstAsync(t => t.Id == partnerBSaleId);
+        Assert.Equal(0m, sale.TotalPaid);
+    }
+
+    [Fact]
+    public async Task PostAsync_ShouldReject_WhenDuplicateRowsOverpayOneTransaction()
+    {
+        // Arrange — two rows for the same sale summing past its remaining (would 500 on the second apply).
+        var walletId = await CreateWalletAsync(0m);
+        var partnerId = await CreatePartnerAsync();
+        var saleId = await CreateOpenSaleAsync(partnerId, total: 10_000m);
+
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
+            Amount: 12_000m, Description: null, Period: null,
+            Settlements: [new SettlementInput(saleId, 6_000m), new SettlementInput(saleId, 6_000m)]);
+
+        // Act & Assert — a clean 400, never a 500, and the sale is untouched.
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+
+        var sale = await _context.Transactions.AsNoTracking().FirstAsync(t => t.Id == saleId);
+        Assert.Equal(0m, sale.TotalPaid);
+    }
+
+    [Fact]
+    public async Task PostAsync_ShouldCollapseDuplicateRows_WhenWithinRemaining()
+    {
+        // Arrange — two rows for the same sale summing to exactly its remaining.
+        var walletId = await CreateWalletAsync(0m);
+        var partnerId = await CreatePartnerAsync();
+        var saleId = await CreateOpenSaleAsync(partnerId, total: 10_000m);
+
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
+            Amount: 10_000m, Description: null, Period: null,
+            Settlements: [new SettlementInput(saleId, 4_000m), new SettlementInput(saleId, 6_000m)]);
+
+        // Act
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+
+        // Assert — one merged allocation of 10,000 and the sale is paid once, not twice.
+        var allocation = Assert.Single(payment.Allocations);
+        Assert.Equal("TransactionSettlement", allocation.AllocationType);
+        Assert.Equal(saleId, allocation.TransactionId);
+        Assert.Equal(10_000m, allocation.Amount);
+
+        var sale = await _context.Transactions.AsNoTracking().FirstAsync(t => t.Id == saleId);
+        Assert.Equal(10_000m, sale.TotalPaid);
+    }
+
+    [Fact]
+    public async Task PostAsync_ShouldMintDistinctNumbers_ForSequentialPayments()
+    {
+        var walletId = await CreateWalletAsync(0m);
+        var partnerId = await CreatePartnerAsync();
+        var firstSaleId = await CreateOpenSaleAsync(partnerId, total: 5_000m);
+        var secondSaleId = await CreateOpenSaleAsync(partnerId, total: 5_000m);
+
+        var first = await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
+            PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
+            Amount: 5_000m, Description: null, Period: null,
+            Settlements: [new SettlementInput(firstSaleId, 5_000m)]));
+
+        var second = await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
+            PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
+            Amount: 5_000m, Description: null, Period: null,
+            Settlements: [new SettlementInput(secondSaleId, 5_000m)]));
+
+        Assert.StartsWith("P-", first.Number);
+        Assert.StartsWith("P-", second.Number);
+        Assert.NotEqual(first.Number, second.Number);
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Sale.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Sale.cs
@@ -230,4 +230,32 @@ public partial class CreateTransactionTests
         var openSale = await _context.Transactions.FirstAsync(t => t.Id == openSaleId);
         Assert.Equal(TransactionStatus.Closed, openSale.Status);
     }
+
+    [Fact]
+    public async Task CreateAsync_ShouldCollapseDuplicateSettlementRows_ForOneTransaction()
+    {
+        // Arrange — an open receivable that will be named twice in the same request's settlements.
+        var partnerId = await CreatePartnerAsync();
+        var openSaleId = await CreateOpenTransactionAsync(partnerId, due: 10_000m, paid: 0m, TransactionType.Sale);
+
+        var walletId = await CreateWalletAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        // Pay 15k: 5k closes this Sale; two 5k rows for the open Sale must collapse to one 10k settlement,
+        // not double-apply (which would 500 on the second AddPayment) or overpay.
+        var request = TransactionRequestFactory.Sale(
+            partnerId, productId, warehouseId, due: 5_000m, walletId, paidAmount: 15_000m,
+            OverpaymentHandling.Change,
+            settlements: [new SettlementInput(openSaleId, 5_000m), new SettlementInput(openSaleId, 5_000m)]);
+
+        // Act
+        await PostTransactionAsync(request);
+
+        // Assert — the open Sale is settled exactly once.
+        var openSale = await _context.Transactions.FirstAsync(t => t.Id == openSaleId);
+        Assert.Equal(10_000m, openSale.TotalPaid);
+        Assert.Equal(TransactionStatus.Closed, openSale.Status);
+    }
 }


### PR DESCRIPTION
Closes the G2 payment-ledger holes (issues-tracker §1).

- **A-BE-1** partner-ownership guard on standalone payment (partner A can no longer settle partner B's transaction).
- **A-BE-2** duplicate-settlement dedup in both the standalone and inline-transaction paths (repeated `TransactionId` no longer overpays/500s). Direction check stays deferred under DR-05.
- **A-BE-3** race-safe numbering: unique `(OrganizationId, Number)` index + retry-on-collision (interim; superseded by DR-21).

Verified: build + full integration suite green except the 3 pre-existing `PasswordResetTests` (OTP-baseline, unrelated). Branch off `redesign/issue-fixes`.
