### PR TITLE
Harden auth/session infrastructure (G3)

### DIFF
--- a/src/Ombor.API/ExceptionHandlers/SmsDeliveryExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/SmsDeliveryExceptionHandler.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Ombor.Domain.Exceptions;
+using Sentry;
+
+namespace Ombor.API.ExceptionHandlers;
+
+/// <summary>
+/// Maps a <see cref="SmsDeliveryException"/> to a 503 ProblemDetails. The client gets a generic
+/// "try again later" message; the provider's detailed reason stays in logs/Sentry.
+/// </summary>
+internal sealed class SmsDeliveryExceptionHandler(ILogger<SmsDeliveryExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not SmsDeliveryException smsException)
+        {
+            return false;
+        }
+
+        var problemDetails = new ProblemDetails
+        {
+            Title = "Service Unavailable",
+            Status = StatusCodes.Status503ServiceUnavailable,
+            Detail = "SMS service is temporarily unavailable. Please try again later.",
+            Type = "https://httpstatuses.com/503",
+            Instance = httpContext.Request.Path
+        };
+
+        httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        // A provider outage is a real operational failure worth a Sentry event (5xx, not user-caused).
+        SentrySdk.CaptureException(smsException);
+
+        logger.LogError(smsException, "SMS delivery failed: {Message}", smsException.Message);
+
+        return true;
+    }
+}

--- a/src/Ombor.API/Extensions/DependencyInjection.cs
+++ b/src/Ombor.API/Extensions/DependencyInjection.cs
@@ -58,6 +58,7 @@ internal static class DependencyInjection
         services.AddExceptionHandler<ConflictExceptionHandler>();
         services.AddExceptionHandler<InvalidOrderStateTransitionExceptionHandler>();
         services.AddExceptionHandler<InvalidFileExceptionHandler>();
+        services.AddExceptionHandler<SmsDeliveryExceptionHandler>();
         services.AddExceptionHandler<GlobalExceptionHandler>();
 
         services.AddProblemDetails();

--- a/src/Ombor.Application/Services/AuthService.cs
+++ b/src/Ombor.Application/Services/AuthService.cs
@@ -71,39 +71,57 @@ internal sealed class AuthService(
             return new VerifyOtpResponse();
         }
 
-        var organization = await organizationService.CreateAsync(registerRequest.OrganizationName);
-
         var passwordHash = passwordHasher.HashPassword(registerRequest.Password);
 
-        var newUser = new User
+        // Org + user + starter data + refresh token are one account: a mid-way failure must not leave an
+        // orphan organization (which a retry can't reuse). Commit them atomically.
+        User newUser;
+        string refreshToken;
+        await using (var transaction = await context.Database.BeginTransactionAsync())
         {
-            FirstName = registerRequest.FirstName,
-            LastName = registerRequest.LastName,
-            TelegramAccount = registerRequest.TelegramAccount,
-            PhoneNumber = registerRequest.PhoneNumber,
-            Email = registerRequest.Email,
-            PasswordHash = passwordHash.Hash,
-            PasswordSalt = passwordHash.Salt,
-            IsPhoneNumberConfirmed = true,
-            // The interface language chosen at registration (validated upstream from the request header).
-            Language = language,
-            OrganizationId = organization.Id,
-            Organization = null! // To be set by EF Core
-        };
+            try
+            {
+                var organization = await organizationService.CreateAsync(registerRequest.OrganizationName);
 
-        context.Users.Add(newUser);
-        await context.SaveChangesAsync();
+                newUser = new User
+                {
+                    FirstName = registerRequest.FirstName,
+                    LastName = registerRequest.LastName,
+                    TelegramAccount = registerRequest.TelegramAccount,
+                    PhoneNumber = registerRequest.PhoneNumber,
+                    Email = registerRequest.Email,
+                    PasswordHash = passwordHash.Hash,
+                    PasswordSalt = passwordHash.Salt,
+                    IsPhoneNumberConfirmed = true,
+                    // The interface language chosen at registration (validated upstream from the request header).
+                    Language = language,
+                    OrganizationId = organization.Id,
+                    Organization = null! // To be set by EF Core
+                };
 
-        // Seed the organization's ordinary starter records (rule 42), named in the registration language.
-        await organizationSetupService.SeedStarterDataAsync(organization.Id, language);
+                context.Users.Add(newUser);
+                await context.SaveChangesAsync();
 
+                // Seed the organization's ordinary starter records (rule 42), named in the registration language.
+                await organizationSetupService.SeedStarterDataAsync(organization.Id, language);
+
+                refreshToken = tokenService.GenerateRefreshToken();
+                await SaveRefreshTokenAsync(newUser, refreshToken);
+
+                await transaction.CommitAsync();
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
+        }
+
+        // Clear the OTP only after the account is durably committed, so a failed attempt can be retried.
         await otpCodeProvider.RemoveOtpAsync(request.PhoneNumber, OtpPurpose.Registration);
         await otpCodeProvider.RemoveRegisterRequestAsync(request.PhoneNumber);
 
         var accessToken = tokenService.GenerateAccessToken(newUser);
-        var refreshToken = tokenService.GenerateRefreshToken();
-
-        await SaveRefreshTokenAsync(newUser, refreshToken);
 
         return new VerifyOtpResponse(refreshToken, accessToken);
     }
@@ -182,8 +200,10 @@ internal sealed class AuthService(
        await context.Users.FirstOrDefaultAsync(x => x.PhoneNumber == phoneNumber)
        ?? throw new EntityNotFoundException<User>(phoneNumber);
 
+    // Bypasses the organization query filter: refresh is anonymous (no org claim) and the user is fetched by
+    // its own id. Without this, a stray org context filters the required User out and token refresh fails.
     private async Task<User> GetOrThrowAsync(int id) =>
-       await context.Users.FirstOrDefaultAsync(x => x.Id == id)
+       await context.Users.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == id)
        ?? throw new EntityNotFoundException<User>(id);
 
     private void VerifyPassword(User user, string password)

--- a/src/Ombor.Domain/Exceptions/SmsDeliveryException.cs
+++ b/src/Ombor.Domain/Exceptions/SmsDeliveryException.cs
@@ -1,0 +1,12 @@
+namespace Ombor.Domain.Exceptions;
+
+/// <summary>
+/// Raised when the SMS provider is unreachable or rejects a message (e.g. an unmoderated template).
+/// Surfaces as HTTP 503 so a failed OTP send reads as "try again later", not an opaque 500.
+/// </summary>
+public sealed class SmsDeliveryException : Exception
+{
+    public SmsDeliveryException(string message) : base(message) { }
+
+    public SmsDeliveryException(string message, Exception? innerException) : base(message, innerException) { }
+}

--- a/src/Ombor.Infrastructure/Extensions/DependencyInjection.cs
+++ b/src/Ombor.Infrastructure/Extensions/DependencyInjection.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +21,20 @@ public static class DependencyInjection
         .AddDatabase(configuration)
         .AddAuthentication(configuration)
         .AddInMemoryCache()
+        .AddKeyPersistence()
         .AddServices();
+
+    private static IServiceCollection AddKeyPersistence(this IServiceCollection services)
+    {
+        // Persist the Data Protection key ring in SQL Server instead of the default ephemeral store, and pin a
+        // fixed application name, so keys survive restarts and are shared across instances.
+        services
+            .AddDataProtection()
+            .PersistKeysToDbContext<ApplicationDbContext>()
+            .SetApplicationName("Ombor");
+
+        return services;
+    }
 
     private static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
     {

--- a/src/Ombor.Infrastructure/Ombor.Infrastructure.csproj
+++ b/src/Ombor.Infrastructure/Ombor.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.20" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.20" />
 	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />

--- a/src/Ombor.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Ombor.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Ombor.Application.Interfaces;
 using Ombor.Domain.Common;
@@ -9,8 +10,11 @@ namespace Ombor.Infrastructure.Persistence;
 internal class ApplicationDbContext(
     DbContextOptions<ApplicationDbContext> options,
     IOrganizationAccessor organizationAccessor)
-    : DbContext(options), IApplicationDbContext
+    : DbContext(options), IApplicationDbContext, IDataProtectionKeyContext
 {
+    /// <summary>Persisted Data Protection key ring, so keys survive restarts and are shared across instances.</summary>
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+
     public virtual DbSet<Category> Categories { get; set; }
     public virtual DbSet<Product> Products { get; set; }
     public virtual DbSet<ProductImage> ProductImages { get; set; }

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260714142335_Add_DataProtectionKeys.Designer.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260714142335_Add_DataProtectionKeys.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombor.Infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using Ombor.Infrastructure.Persistence;
 namespace Ombor.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714142335_Add_DataProtectionKeys")]
+    partial class Add_DataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260714142335_Add_DataProtectionKeys.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260714142335_Add_DataProtectionKeys.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombor.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_DataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FriendlyName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Xml = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/src/Ombor.Infrastructure/Services/SmsService.cs
+++ b/src/Ombor.Infrastructure/Services/SmsService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Ombor.Application.Configurations;
 using Ombor.Application.Interfaces;
 using Ombor.Application.Models;
+using Ombor.Domain.Exceptions;
 
 namespace Ombor.Infrastructure.Services;
 
@@ -51,13 +52,25 @@ internal sealed class SmsService(
             "application/json"
         );
 
-        using var response = await client.SendAsync(request);
-
-        if (!response.IsSuccessStatusCode)
+        HttpResponseMessage response;
+        try
         {
-            var error = await response.Content.ReadAsStringAsync();
+            response = await client.SendAsync(request);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Network/DNS failure reaching the provider — surface as a retryable outage, not a 500.
+            throw new SmsDeliveryException("SMS provider is temporarily unavailable.", ex);
+        }
 
-            throw new HttpRequestException($"SMS provider request failed with status {(int)response.StatusCode} {response.ReasonPhrase}. Response: {error}");
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync();
+
+                throw new SmsDeliveryException($"SMS provider request failed with status {(int)response.StatusCode} {response.ReasonPhrase}. Response: {error}");
+            }
         }
     }
 }

--- a/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthRefreshTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthRefreshTests.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using Ombor.Contracts.Responses.Auth;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.AuthEndpoints;
+
+public sealed class AuthRefreshTests(TestingWebApplicationFactory factory, ITestOutputHelper output)
+    : AuthTestsBase(factory, output)
+{
+    private const string Password = "OldPassw0rd";
+
+    [Fact]
+    public async Task RefreshToken_IssuesNewTokens_ForAValidRefreshToken()
+    {
+        // Regression guard for the refresh path: the user re-fetch bypasses the org query filter, so a valid
+        // refresh token still resolves its user and yields fresh tokens.
+        var (_, phone) = await SeedUserAsync(Password);
+
+        var login = await _client.PostAsync<LoginResponse>(
+            "auth/login", new { phoneNumber = phone, password = Password }, HttpStatusCode.OK);
+
+        var refreshed = await _client.PostAsync<RefreshTokenResponse>(
+            "auth/refresh-token", new { refreshToken = login.RefreshToken }, HttpStatusCode.OK);
+
+        Assert.False(string.IsNullOrEmpty(refreshed.AccessToken));
+        Assert.False(string.IsNullOrEmpty(refreshed.RefreshToken));
+    }
+}

--- a/tests/Ombor.Tests.Unit/Services/SmsServiceTests.cs
+++ b/tests/Ombor.Tests.Unit/Services/SmsServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using Moq;
+using Ombor.Application.Configurations;
+using Ombor.Application.Interfaces;
+using Ombor.Application.Models;
+using Ombor.Domain.Exceptions;
+using Ombor.Infrastructure.Services;
+
+namespace Ombor.Tests.Unit.Services;
+
+public sealed class SmsServiceTests
+{
+    private static readonly SmsMessage Message = new("+998900000000", "code 1234", "Ombor");
+
+    private static SmsService CreateService(HttpMessageHandler handler)
+    {
+        var validator = new Mock<IRequestValidator>();
+        validator
+            .Setup(v => v.ValidateAndThrowAsync(It.IsAny<SmsMessage>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var settings = Options.Create(new SmsSettings
+        {
+            Token = "token",
+            ApiUrl = "https://sms.example.test/send",
+            FromNumber = "Ombor",
+        });
+
+        return new SmsService(validator.Object, new HttpClient(handler), settings);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ShouldThrowSmsDeliveryException_WhenProviderRejects()
+    {
+        var service = CreateService(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("provider error"),
+        }));
+
+        await Assert.ThrowsAsync<SmsDeliveryException>(() => service.SendMessageAsync(Message));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ShouldThrowSmsDeliveryException_WhenProviderUnreachable()
+    {
+        var service = CreateService(new ThrowingHandler());
+
+        await Assert.ThrowsAsync<SmsDeliveryException>(() => service.SendMessageAsync(Message));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_ShouldSucceed_WhenProviderAccepts()
+    {
+        var service = CreateService(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        await service.SendMessageAsync(Message);
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(responder(request));
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("network down");
+    }
+}


### PR DESCRIPTION
G3 auth/session infra (issues-tracker §4).

- Refresh survives an org context — `IgnoreQueryFilters()` on the refresh user re-fetch (User/RefreshToken filter, S 1R).
- Atomic registration (`BeginTransactionAsync`; CR A-BE-4).
- Persisted Data Protection keys (`PersistKeysToDbContext` + `SetApplicationName`; S 2G/2Q).
- Typed `SmsDeliveryException` → 503 (S 2M).

Recon note: prod cookie config was already correct. Full response localization (DEC-9) deferred. Suite green except the 3 pre-existing OTP tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMS provider failures now return a temporary service-unavailable response with a clear retry message.
  * Registration verification now completes related account setup atomically, preventing partial account creation.
  * Refresh-token flows can now resolve valid users reliably.

* **Improvements**
  * Authentication protection keys are persisted across application restarts.
  * Added coverage for SMS delivery failures, successful delivery, and refresh-token issuance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->