### PR TITLE
Cut Sentry noise and fix error-shape (G5)

### DIFF
--- a/src/Ombor.API/ExceptionHandlers/ConflictExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/ConflictExceptionHandler.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Ombor.Domain.Exceptions;
-using Sentry;
 
 namespace Ombor.API.ExceptionHandlers;
 
@@ -29,8 +28,7 @@ internal sealed class ConflictExceptionHandler(ILogger<ConflictExceptionHandler>
         httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
 
-        SentrySdk.CaptureException(conflictException);
-
+        // 409s are client errors, not Sentry events — log locally only.
         logger.LogWarning(conflictException, "Conflict: {Message}", conflictException.Message);
 
         return true;

--- a/src/Ombor.API/ExceptionHandlers/EntityNotFoundExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/EntityNotFoundExceptionHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Ombor.Domain.Exceptions;
-using Sentry;
 
 namespace Ombor.API.ExceptionHandlers;
 
@@ -26,8 +25,7 @@ internal sealed class EntityNotFoundExceptionHandler(ILogger<EntityNotFoundExcep
         httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
 
-        SentrySdk.CaptureException(entityNotFoundException);
-
+        // 404s are client errors, not Sentry events — log locally only.
         logger.LogWarning(
             exception,
             "{Type} with ID: {Id} was not found.",

--- a/src/Ombor.API/ExceptionHandlers/InvalidFileExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/InvalidFileExceptionHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Ombor.Domain.Exceptions;
-using Sentry;
 
 namespace Ombor.API.ExceptionHandlers;
 
@@ -25,12 +24,11 @@ internal sealed class InvalidFileExceptionHandler(ILogger<InvalidFileException> 
         httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
 
+        // 400s are client errors, not Sentry events — log locally only.
         logger.LogWarning(
             exception,
             "Error while processing file. {Message}",
             fileException.Message);
-
-        SentrySdk.CaptureException(fileException);
 
         return true;
     }

--- a/src/Ombor.API/ExceptionHandlers/InvalidOrderStateTransitionExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/InvalidOrderStateTransitionExceptionHandler.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Ombor.Domain.Exceptions;
-using Sentry;
 
 namespace Ombor.API.ExceptionHandlers;
 
@@ -30,8 +29,7 @@ internal sealed class InvalidOrderStateTransitionExceptionHandler(
         httpContext.Response.StatusCode = StatusCodes.Status409Conflict;
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
 
-        SentrySdk.CaptureException(transitionException);
-
+        // 409s are client errors, not Sentry events — log locally only.
         logger.LogWarning(transitionException, "Invalid order state transition: {Message}", transitionException.Message);
 
         return true;

--- a/src/Ombor.API/ExceptionHandlers/UnauthorizedAccessExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/UnauthorizedAccessExceptionHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ombor.API.ExceptionHandlers;
+
+/// <summary>
+/// Maps an <see cref="UnauthorizedAccessException"/> (bad credentials, invalid/expired refresh token,
+/// deactivated account) to a 401 ProblemDetails. A client auth failure is not a server fault, so it is
+/// logged locally but not sent to Sentry.
+/// </summary>
+internal sealed class UnauthorizedAccessExceptionHandler(ILogger<UnauthorizedAccessExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not UnauthorizedAccessException unauthorizedException)
+        {
+            return false;
+        }
+
+        var problemDetails = new ProblemDetails
+        {
+            Title = "Unauthorized",
+            Status = StatusCodes.Status401Unauthorized,
+            Detail = unauthorizedException.Message,
+            Type = "https://httpstatuses.com/401",
+            Instance = httpContext.Request.Path
+        };
+
+        httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        logger.LogWarning(unauthorizedException, "Unauthorized: {Message}", unauthorizedException.Message);
+
+        return true;
+    }
+}

--- a/src/Ombor.API/ExceptionHandlers/ValidationExceptionHandler.cs
+++ b/src/Ombor.API/ExceptionHandlers/ValidationExceptionHandler.cs
@@ -33,8 +33,7 @@ internal sealed class ValidationExceptionHandler(ILogger<ValidationExceptionHand
         httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
         await httpContext.Response.WriteAsJsonAsync(problem, cancellationToken);
 
-        SentrySdk.CaptureException(validationException);
-
+        // 400s are client errors, not Sentry events — log locally only.
         logger.LogWarning(validationException, "Validation failed: {Errors}", errors);
 
         return true;

--- a/src/Ombor.API/Extensions/DependencyInjection.cs
+++ b/src/Ombor.API/Extensions/DependencyInjection.cs
@@ -58,6 +58,7 @@ internal static class DependencyInjection
         services.AddExceptionHandler<ConflictExceptionHandler>();
         services.AddExceptionHandler<InvalidOrderStateTransitionExceptionHandler>();
         services.AddExceptionHandler<InvalidFileExceptionHandler>();
+        services.AddExceptionHandler<UnauthorizedAccessExceptionHandler>();
         services.AddExceptionHandler<GlobalExceptionHandler>();
 
         services.AddProblemDetails();

--- a/src/Ombor.API/Program.cs
+++ b/src/Ombor.API/Program.cs
@@ -1,5 +1,7 @@
+using FluentValidation;
 using Ombor.API.Extensions;
 using Ombor.Application.Extensions;
+using Ombor.Domain.Exceptions;
 using Ombor.Infrastructure.Extensions;
 using Ombor.TestDataGenerator.Extensions;
 
@@ -7,13 +9,18 @@ var builder = WebApplication.CreateBuilder(args);
 
 if (builder.Environment.IsProduction())
 {
-    builder.WebHost.UseSentry();
+    builder.WebHost.UseSentry(options =>
+    {
+        // 4xx / auth failures are client errors, not server faults — keep them out of the Sentry issue stream.
+        options.SetBeforeSend(static (SentryEvent @event, SentryHint _) =>
+            @event.Exception is ValidationException or EntityNotFoundException or UnauthorizedAccessException
+                ? null
+                : @event);
+    });
 }
 
 try
 {
-    SentrySdk.CaptureMessage("Starting API...");
-
     builder.Services
         .AddApi(builder.Configuration)
         .AddApplication(builder.Configuration)
@@ -44,8 +51,6 @@ try
     app.UseStaticFiles();
 
     await app.UseDatabaseSeederAsync();
-
-    SentrySdk.CaptureMessage("API started...");
 
     await app.RunAsync();
 }

--- a/src/Ombor.API/appsettings.Production.json
+++ b/src/Ombor.API/appsettings.Production.json
@@ -26,12 +26,12 @@
   },
   "Sentry": {
     "Dsn": "",
-    "SendDefaultPii": true,
+    "SendDefaultPii": false,
     "MaxRequestBodySize": "Always",
     "MinimumBreadcrumbLevel": "Debug",
     "MinimumEventLevel": "Warning",
     "AttachStackTrace": true,
-    "Debug": true,
+    "Debug": false,
     "DiagnosticLevel": "Error"
   },
   "JwtSettings": {

--- a/src/Ombor.Application/Interfaces/IRequestValidator.cs
+++ b/src/Ombor.Application/Interfaces/IRequestValidator.cs
@@ -9,7 +9,7 @@ public interface IRequestValidator
     /// Validates the specified <paramref name="request"/> asynchronously.
     /// </summary>
     /// <typeparam name="TRequest">Type of the request to validate.</typeparam>
-    /// <param name="request">The instance to validate. Cannot be <c>null</c>.</param>
+    /// <param name="request">The instance to validate.</param>
     /// <param name="cancellationToken">
     /// A <see cref="CancellationToken"/> to observe while waiting for the validation to complete.
     /// </param>
@@ -17,14 +17,11 @@ public interface IRequestValidator
     /// A <see cref="Task"/> that completes if validation succeeds, or faults with
     /// <see cref="FluentValidation.ValidationException"/> if validation fails.
     /// </returns>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown if <paramref name="request"/> is <c>null</c>.
-    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown if no <see cref="FluentValidation.IValidator{TRequest}"/> is registered for <typeparamref name="TRequest"/>.
     /// </exception>
     /// <exception cref="FluentValidation.ValidationException">
-    /// Thrown if one or more validation rules fail.
+    /// Thrown if <paramref name="request"/> is <c>null</c> or one or more validation rules fail.
     /// </exception>
     Task ValidateAndThrowAsync<TRequest>(TRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Ombor.Application/Services/RequestValidator.cs
+++ b/src/Ombor.Application/Services/RequestValidator.cs
@@ -8,7 +8,11 @@ internal sealed class RequestValidator(IServiceProvider serviceProvider) : IRequ
 {
     public async Task ValidateAndThrowAsync<TRequest>(TRequest request, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(request);
+        if (request is null)
+        {
+            // A missing/null request body is a client error — surface it as a 400, not a 500.
+            throw new ValidationException("Request body is required.");
+        }
 
         var validator = serviceProvider.GetRequiredService<IValidator<TRequest>>();
         var result = await validator.ValidateAsync(request, cancellationToken);

--- a/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthErrorShapeTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthErrorShapeTests.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.AuthEndpoints;
+
+public sealed class AuthErrorShapeTests(TestingWebApplicationFactory factory, ITestOutputHelper output)
+    : AuthTestsBase(factory, output)
+{
+    [Fact]
+    public async Task Login_ReturnsUnauthorized_ForAWrongPassword()
+    {
+        // A bad credential is a 401 client error, not a 500 — routed through UnauthorizedAccessExceptionHandler.
+        var (_, phone) = await SeedUserAsync("OldPassw0rd");
+
+        await _client.PostAsync<ProblemDetails>(
+            "auth/login", new { phoneNumber = phone, password = "WrongPassw0rd" }, HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Ombor.Tests.Unit/Services/RequestValidatorTests.cs
+++ b/tests/Ombor.Tests.Unit/Services/RequestValidatorTests.cs
@@ -17,13 +17,13 @@ public sealed class RequestValidatorTests
     }
 
     [Fact]
-    public async Task ValidateAndThrowAsync_ShouldThrowArgumentNullException_WhenRequestIsNull()
+    public async Task ValidateAndThrowAsync_ShouldThrowValidationException_WhenRequestIsNull()
     {
-        // Arrange
+        // Arrange — a null body is a client error (400), not a server fault.
         object request = null!;
 
         // Act & Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => _validator.ValidateAndThrowAsync(request));
+        await Assert.ThrowsAsync<ValidationException>(() => _validator.ValidateAndThrowAsync(request));
     }
 
     [Fact]


### PR DESCRIPTION
G5 observability / error-shape (issues-tracker §4).

- 4xx/404/409 handlers no longer `CaptureException`; `BeforeSend` drops Validation/EntityNotFound/UnauthorizedAccess; startup info messages removed.
- `UnauthorizedAccessException` → 401; null request body → clean 400 (`RequestValidator`).
- Production Sentry `SendDefaultPii`/`Debug` = false (CR A-BE-6).

EntityNotFound was already 404. Suite green except the 3 pre-existing OTP tests.
