### PR TITLE
Backend data/query hygiene (G5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,12 @@ permissions:
   contents: read
   packages: write
 
+# Serialize deploys per branch so overlapping pushes can't repoint the shared ':latest' tag to an older
+# commit — the last-pushed commit deploys last. Don't cancel an in-flight deploy mid-SSH.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   setup:
     name: Resolve environment from branch

--- a/src/Ombor.Infrastructure/Extensions/DependencyInjection.cs
+++ b/src/Ombor.Infrastructure/Extensions/DependencyInjection.cs
@@ -28,7 +28,10 @@ public static class DependencyInjection
 
         services.AddDbContext<IApplicationDbContext, ApplicationDbContext>((serviceProvider, options) =>
             options
-                .UseSqlServer(configuration.GetConnectionString("DefaultConnection"))
+                // Split multi-collection includes into separate queries to avoid cartesian-explosion warnings.
+                .UseSqlServer(
+                    configuration.GetConnectionString("DefaultConnection"),
+                    sql => sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
                 .AddInterceptors(serviceProvider.GetRequiredService<AuditSaveChangesInterceptor>()));
 
         return services;

--- a/src/Ombor.TestDataGenerator/Seeders/ProductionDatabaseSeeder.cs
+++ b/src/Ombor.TestDataGenerator/Seeders/ProductionDatabaseSeeder.cs
@@ -102,7 +102,9 @@ internal sealed class ProductionDatabaseSeeder(
         var fileNames = nameMap.Keys.ToArray();
         if (fileNames.Length == 0)
         {
-            throw new InvalidOperationException("No seed images were loaded.");
+            // Product images are decorative seed data — a missing/empty image source must not abort the
+            // whole seed (and app startup). Skip image seeding instead of throwing.
+            return;
         }
 
         var productIds = context.Products.Select(p => p.Id).ToArray();


### PR DESCRIPTION
G5 data/query hygiene (issues-tracker §4).

- Global `QuerySplittingBehavior.SplitQuery` (clears the 13 cartesian-explosion warnings).
- Tolerant image seeder (skip + continue on a missing source instead of aborting seed/startup).
- Deploy workflow `concurrency:` group on `deploy.yml` (stops the `:latest` race, CR A-BE-7).

`WarehouseId=0` backfill deferred pending a dev/prod row audit. Suite green except the 3 pre-existing OTP tests.
