### PR TITLE
Relax partner phone validation to length-only (G6)

### DIFF
--- a/src/Ombor.Application/Validators/ValidationHelpers.cs
+++ b/src/Ombor.Application/Validators/ValidationHelpers.cs
@@ -1,11 +1,24 @@
-﻿using System.Text.RegularExpressions;
-
 namespace Ombor.Application.Validators;
 
 internal static class ValidationHelpers
 {
-    private const string UzPhonePattern = @"^(?:\+998-?)?(?:9\d{8}|9\d-\d{3}-\d{2}-\d{2}|9\d{2}-\d{3}-\d{3})$";
+    // Uzbek numbers are 9 national digits (e.g. 90 123 45 67); with the +998 country code, 12.
+    private const int NationalNumberLength = 9;
+    private const int WithCountryCodeLength = 12;
 
-    public static bool IsValidPhoneNumber(string phoneNumber) =>
-        Regex.IsMatch(phoneNumber, UzPhonePattern, RegexOptions.None, TimeSpan.FromMilliseconds(100));
+    // Policy (F): accept any Uzbek number under +998, validating length only — not the operator prefix —
+    // so landlines and every mobile operator pass. Formatting characters (+, spaces, dashes) are ignored.
+    // Length-based rather than prefix-stripping: a national mobile can itself start with "998".
+    public static bool IsValidPhoneNumber(string phoneNumber)
+    {
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            return false;
+        }
+
+        var digits = new string(phoneNumber.Where(char.IsDigit).ToArray());
+
+        return digits.Length == NationalNumberLength
+            || (digits.Length == WithCountryCodeLength && digits.StartsWith("998", StringComparison.Ordinal));
+    }
 }

--- a/tests/Ombor.Tests.Unit/Validators/ValidationHelpersTests.cs
+++ b/tests/Ombor.Tests.Unit/Validators/ValidationHelpersTests.cs
@@ -1,0 +1,28 @@
+using Ombor.Application.Validators;
+
+namespace Ombor.Tests.Unit.Validators;
+
+public sealed class ValidationHelpersTests
+{
+    [Theory]
+    // Accepted: +998 country code + 9 national digits, any operator, any formatting.
+    [InlineData("+998-90-123-45-67")]
+    [InlineData("+998911101212")]
+    [InlineData("+99890-100-00-00")]
+    [InlineData("+998711234567")]   // landline (71), previously rejected by the mobile-only rule
+    [InlineData("998812345678")]    // no plus, still 998 + 9 national
+    [InlineData("901234567")]       // national number only
+    public void IsValidPhoneNumber_ReturnsTrue_ForUzbekNumbers(string phoneNumber)
+        => Assert.True(ValidationHelpers.IsValidPhoneNumber(phoneNumber));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("asdasd")]
+    [InlineData("++654++321")]       // only 6 digits
+    [InlineData("qwerty123")]        // only 3 digits
+    [InlineData("12345")]            // too short
+    [InlineData("+998901234567890")] // too long
+    public void IsValidPhoneNumber_ReturnsFalse_ForInvalidNumbers(string phoneNumber)
+        => Assert.False(ValidationHelpers.IsValidPhoneNumber(phoneNumber));
+}


### PR DESCRIPTION
G6 backend half (issues-tracker §4). Relaxes `ValidationHelpers.IsValidPhoneNumber` to length-only under `+998` (9 national digits, or 12 with the `998` country code) so landlines and every operator pass — length-based, not prefix-stripping (a mobile can itself start with `998`). Covered by unit tests.
