### PR TITLE
Order-history doc + login language (§12: DEC-10, A18)

### DIFF
--- a/src/Ombor.Application/Services/AuthService.cs
+++ b/src/Ombor.Application/Services/AuthService.cs
@@ -127,7 +127,7 @@ internal sealed class AuthService(
 
         await SaveRefreshTokenAsync(user, refreshToken);
 
-        return new LoginResponse(accessToken, refreshToken);
+        return new LoginResponse(accessToken, refreshToken, user.Language);
     }
 
     public async Task<RefreshTokenResponse> RefreshTokenAsync(RefreshTokenRequest request)

--- a/src/Ombor.Contracts/Responses/Auth/LoginResponse.cs
+++ b/src/Ombor.Contracts/Responses/Auth/LoginResponse.cs
@@ -1,3 +1,7 @@
 ﻿namespace Ombor.Contracts.Responses.Auth;
 
-public sealed record LoginResponse(string AccessToken, string RefreshToken);
+/// <summary>The tokens issued on a successful login, plus the user's saved interface language.</summary>
+/// <param name="AccessToken">The JWT access token.</param>
+/// <param name="RefreshToken">The refresh token (also set as an httpOnly cookie).</param>
+/// <param name="Language">The user's saved interface language (ru / uz-Latn / uz-Cyrl), so a fresh device restores it.</param>
+public sealed record LoginResponse(string AccessToken, string RefreshToken, string Language);

--- a/src/Ombor.Contracts/Responses/Order/OrderDto.cs
+++ b/src/Ombor.Contracts/Responses/Order/OrderDto.cs
@@ -19,7 +19,7 @@ namespace Ombor.Contracts.Responses.Order;
 /// <param name="WarehouseName">The intended warehouse name, if any.</param>
 /// <param name="SaleId">The Sale this order was promoted into on delivery; null until delivered.</param>
 /// <param name="Lines">The order lines.</param>
-/// <param name="History">The status-transition history, newest-first.</param>
+/// <param name="History">The status-transition history, oldest-first.</param>
 public sealed record OrderDto(
     int Id,
     int CustomerId,

--- a/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthLoginTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthLoginTests.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using Ombor.Contracts.Responses.Auth;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.AuthEndpoints;
+
+public sealed class AuthLoginTests(TestingWebApplicationFactory factory, ITestOutputHelper output)
+    : AuthTestsBase(factory, output)
+{
+    [Fact]
+    public async Task Login_ReturnsTheUsersSavedLanguage()
+    {
+        // A18: login carries the saved language so a fresh device restores the user's interface locale.
+        var (_, phone) = await SeedUserAsync("OldPassw0rd");
+
+        var login = await _client.PostAsync<LoginResponse>(
+            "auth/login", new { phoneNumber = phone, password = "OldPassw0rd" }, HttpStatusCode.OK);
+
+        Assert.Equal("ru", login.Language); // SeedUserAsync leaves the default User.Language ("ru")
+    }
+}


### PR DESCRIPTION
Two small §12 alignment fixes.

- **DEC-10**: order status-history is ruled oldest-first and the code already sorts that way — corrected the `OrderDto.History` doc-comment.
- **A18**: `LoginResponse` now returns the user's saved `Language`, so a fresh device restores the interface locale.

Covered by a login integration test. Suite green except the 3 pre-existing OTP tests.
