### PR TITLE
Hard-block wallet overdraft + fix payment-form balance (DR-25)

### DIFF
--- a/src/Ombor.Application/Extensions/WalletCalculationExtensions.cs
+++ b/src/Ombor.Application/Extensions/WalletCalculationExtensions.cs
@@ -1,0 +1,59 @@
+using System.Linq.Expressions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.EntityFrameworkCore;
+using Ombor.Application.Interfaces;
+using Ombor.Domain.Entities;
+using Ombor.Domain.Enums;
+
+namespace Ombor.Application.Extensions;
+
+/// <summary>
+/// One canonical wallet-balance calculation, so every consumer (wallet DTO, payment form, overdraft
+/// guards, transfers) agrees and can't drift. Balance = opening + transfers in − transfers out +
+/// wallet-source payment income − wallet-source payment expense (only Wallet-source components move
+/// wallet cash, signed by the payment direction — rule 15).
+/// </summary>
+internal static class WalletCalculationExtensions
+{
+    private static readonly Expression<Func<Wallet, decimal>> BalanceSelector = w =>
+        w.OpeningBalance
+        + (w.IncomingTransfers.Sum(t => (decimal?)t.Amount) ?? 0m)
+        - (w.OutgoingTransfers.Sum(t => (decimal?)t.Amount) ?? 0m)
+        + (w.Components
+            .Where(c => c.SourceType == PaymentSourceType.Wallet && c.Payment.Direction == PaymentDirection.Income)
+            .Sum(c => (decimal?)c.Amount) ?? 0m)
+        - (w.Components
+            .Where(c => c.SourceType == PaymentSourceType.Wallet && c.Payment.Direction == PaymentDirection.Expense)
+            .Sum(c => (decimal?)c.Amount) ?? 0m);
+
+    public static Task<decimal> ComputeWalletBalanceAsync(this IApplicationDbContext context, int walletId)
+        => context.Wallets
+            .Where(w => w.Id == walletId)
+            .Select(BalanceSelector)
+            .FirstAsync();
+
+    /// <summary>
+    /// Hard-blocks a wallet debit that would overdraw it (DR-25 — parity with the negative-stock block,
+    /// rule 20), mirroring the inter-wallet transfer guard. Surfaces as a 400 with available-vs-requested detail.
+    /// </summary>
+    public static async Task EnsureWalletCanCoverAsync(this IApplicationDbContext context, int walletId, decimal amount)
+    {
+        var balance = await context.ComputeWalletBalanceAsync(walletId);
+
+        if (amount > balance)
+        {
+            var name = await context.Wallets
+                .Where(w => w.Id == walletId)
+                .Select(w => w.Name)
+                .FirstOrDefaultAsync();
+
+            throw new ValidationException(
+            [
+                new ValidationFailure(
+                    "Amount",
+                    $"Insufficient balance in wallet '{name}'. Available: {balance}, requested: {amount}."),
+            ]);
+        }
+    }
+}

--- a/src/Ombor.Application/Services/PaymentService.cs
+++ b/src/Ombor.Application/Services/PaymentService.cs
@@ -44,6 +44,12 @@ internal sealed class PaymentService(
             throw new ValidationException("Settlements cannot exceed the payment amount.");
         }
 
+        // DR-25: an expense may not overdraw the source wallet (parity with the negative-stock block, rule 20).
+        if (request.Direction.ToDomainDirection() == PaymentDirection.Expense)
+        {
+            await context.EnsureWalletCanCoverAsync(wallet.Id, request.Amount);
+        }
+
         var settledIds = settlements.Select(s => s.TransactionId).ToArray();
         var transactions = await context.Transactions
             .Where(t => settledIds.Contains(t.Id))
@@ -177,17 +183,22 @@ internal sealed class PaymentService(
             .Select(e => new PaymentFormEmployeeDto(e.Id, e.FullName, e.Position, e.Salary))
             .ToArrayAsync();
 
-        var wallets = await context.Wallets
+        var walletRows = await context.Wallets
             .Where(w => !w.IsArchived)
             .OrderBy(w => w.Name)
-            .Select(w => new PaymentFormWalletDto(
-                w.Id,
-                w.Name,
-                w.Type.ToString(),
-                w.OpeningBalance
-                    + (w.IncomingTransfers.Sum(t => (decimal?)t.Amount) ?? 0m)
-                    - (w.OutgoingTransfers.Sum(t => (decimal?)t.Amount) ?? 0m)))
+            .Select(w => new { w.Id, w.Name, Type = w.Type.ToString() })
             .ToArrayAsync();
+
+        var wallets = new PaymentFormWalletDto[walletRows.Length];
+        for (var i = 0; i < walletRows.Length; i++)
+        {
+            var w = walletRows[i];
+            // Full computed balance incl. payment activity, via the shared calculator — the form must
+            // match the wallets list (a payment-only wallet used to show 0 here while the list showed its
+            // real, possibly negative, balance).
+            var balance = await context.ComputeWalletBalanceAsync(w.Id);
+            wallets[i] = new PaymentFormWalletDto(w.Id, w.Name, w.Type, balance);
+        }
 
         return new PaymentFormDataDto(partners, employees, wallets);
     }
@@ -298,6 +309,9 @@ internal sealed class PaymentService(
 
         var wallet = await context.Wallets.FirstOrDefaultAsync(w => w.Id == request.WalletId)
             ?? throw new EntityNotFoundException<Wallet>(request.WalletId);
+
+        // DR-25: payroll always leaves the wallet — it may not overdraw it (parity with negative stock, rule 20).
+        await context.EnsureWalletCanCoverAsync(wallet.Id, request.Amount);
 
         var payment = new Payment
         {

--- a/src/Ombor.Application/Services/TransactionService.cs
+++ b/src/Ombor.Application/Services/TransactionService.cs
@@ -320,6 +320,13 @@ internal sealed class TransactionService(
             ? request.PaidAmount - excess
             : request.PaidAmount;
 
+        // DR-25: a money-out transaction (Supply / SaleRefund) may not overdraw the source wallet (parity with
+        // negative stock, rule 20). This runs inside the create transaction, so a block rolls the stock move back.
+        if (direction == PaymentDirection.Expense)
+        {
+            await context.EnsureWalletCanCoverAsync(walletId, sourceAmount);
+        }
+
         payment.Components.Add(new PaymentComponent
         {
             Payment = payment,

--- a/src/Ombor.Application/Services/WalletService.cs
+++ b/src/Ombor.Application/Services/WalletService.cs
@@ -295,15 +295,9 @@ internal sealed class WalletService(
         return ToDto(row);
     }
 
-    private async Task<decimal> ComputeBalanceAsync(int walletId)
-    {
-        var row = await context.Wallets
-            .Where(w => w.Id == walletId)
-            .Select(WalletProjection())
-            .FirstAsync();
-
-        return Balance(row);
-    }
+    // The transfer overdraft guard shares the one canonical balance formula (WalletCalculationExtensions).
+    private Task<decimal> ComputeBalanceAsync(int walletId)
+        => context.ComputeWalletBalanceAsync(walletId);
 
     private async Task EnsureNameIsUniqueAsync(string name, int? excludingId)
     {

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePayrollTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePayrollTests.cs
@@ -19,7 +19,7 @@ public sealed class CreatePayrollTests(TestingWebApplicationFactory factory, ITe
     public async Task PostAsync_ShouldRecordPayroll_AsWalletSourcedExpense()
     {
         // Arrange
-        var walletId = await CreateWalletAsync(0m);
+        var walletId = await CreateWalletAsync(10_000_000m); // funded: payroll may not overdraw the wallet (DR-25)
         var employeeId = await CreateEmployeeAsync(salary: 5_000_000m);
 
         var request = new CreatePayrollRequest(employeeId, walletId, Amount: 4_000_000m, Period: "2026-06", Notes: "June salary");
@@ -46,7 +46,7 @@ public sealed class CreatePayrollTests(TestingWebApplicationFactory factory, ITe
     public async Task PostAsync_ShouldSnapshotSalary_IndependentOfLaterSalaryChange()
     {
         // Arrange
-        var walletId = await CreateWalletAsync(0m);
+        var walletId = await CreateWalletAsync(10_000_000m); // funded: payroll may not overdraw the wallet (DR-25)
         var employeeId = await CreateEmployeeAsync(salary: 5_000_000m);
 
         var request = new CreatePayrollRequest(employeeId, walletId, Amount: 5_000_000m, Period: "2026-06", Notes: null);
@@ -66,7 +66,7 @@ public sealed class CreatePayrollTests(TestingWebApplicationFactory factory, ITe
     public async Task PostAsync_ShouldAllowMultiplePayrolls_ForSameEmployeeAndPeriod()
     {
         // Arrange
-        var walletId = await CreateWalletAsync(0m);
+        var walletId = await CreateWalletAsync(10_000_000m); // funded: payroll may not overdraw the wallet (DR-25)
         var employeeId = await CreateEmployeeAsync(salary: 5_000_000m);
 
         var first = new CreatePayrollRequest(employeeId, walletId, Amount: 2_000_000m, Period: "2026-06", Notes: "advance");
@@ -95,7 +95,7 @@ public sealed class CreatePayrollTests(TestingWebApplicationFactory factory, ITe
     [Fact]
     public async Task PostAsync_ShouldReturnBadRequest_WhenAmountNotPositive()
     {
-        var walletId = await CreateWalletAsync(0m);
+        var walletId = await CreateWalletAsync(10_000_000m); // funded: payroll may not overdraw the wallet (DR-25)
         var employeeId = await CreateEmployeeAsync(salary: 5_000_000m);
 
         var request = new CreatePayrollRequest(employeeId, walletId, Amount: 0m, Period: "2026-06", Notes: null);

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/WalletOverdraftTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/WalletOverdraftTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Payment;
+using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.PaymentEndpoints;
+
+/// <summary>
+/// DR-25: a wallet may not be overdrawn by an expense (parity with the negative-stock block, rule 20),
+/// and the payment form's wallet balance must reflect real payment activity.
+/// </summary>
+public sealed class WalletOverdraftTests(TestingWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : PaymentTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task PostAsync_ShouldReject_WhenExpenseOverdrawsWallet()
+    {
+        var walletId = await CreateWalletAsync(3_000m);
+
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.General, PaymentDirection.Expense, null, null, walletId,
+            Amount: 5_000m, Description: "office supplies", Period: null, Settlements: []);
+
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PostAsync_ShouldAllow_WhenExpenseWithinBalance()
+    {
+        var walletId = await CreateWalletAsync(10_000m);
+
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.General, PaymentDirection.Expense, null, null, walletId,
+            Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []);
+
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+        Assert.Equal("Expense", payment.Direction);
+    }
+
+    [Fact]
+    public async Task FormData_WalletBalance_ReflectsPaymentActivity()
+    {
+        // The form balance used to ignore payments (showed opening) — it must match the real balance now.
+        var walletId = await CreateWalletAsync(10_000m);
+        await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
+            PaymentType.General, PaymentDirection.Expense, null, null, walletId,
+            Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []));
+
+        var form = await _client.GetAsync<PaymentFormDataDto>($"{GetUrl()}/form-data");
+
+        var wallet = Assert.Single(form.Wallets, w => w.Id == walletId);
+        Assert.Equal(6_000m, wallet.Balance);
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Supply.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Supply.cs
@@ -18,7 +18,7 @@ public partial class CreateTransactionTests
     {
         // Arrange
         var partnerId = await CreatePartnerAsync();
-        var walletId = await CreateWalletAsync();
+        var walletId = await CreateWalletAsync(1_000_000m); // funded: a Supply tender may not overdraw the wallet (DR-25)
         var warehouseId = await CreateWarehouseAsync();
         var productId = await CreateProductAsync();
 
@@ -47,7 +47,7 @@ public partial class CreateTransactionTests
     {
         // Arrange
         var partnerId = await CreatePartnerAsync();
-        var walletId = await CreateWalletAsync();
+        var walletId = await CreateWalletAsync(1_000_000m); // funded: a Supply tender may not overdraw the wallet (DR-25)
         var warehouseId = await CreateWarehouseAsync();
         var productId = await CreateProductAsync();
 
@@ -92,7 +92,7 @@ public partial class CreateTransactionTests
     {
         // Arrange
         var partnerId = await CreatePartnerAsync();
-        var walletId = await CreateWalletAsync();
+        var walletId = await CreateWalletAsync(1_000_000m); // funded: a Supply tender may not overdraw the wallet (DR-25)
         var warehouseId = await CreateWarehouseAsync();
         var productId = await CreateProductAsync();
 
@@ -125,7 +125,7 @@ public partial class CreateTransactionTests
     {
         // Arrange
         var partnerId = await CreatePartnerAsync();
-        var walletId = await CreateWalletAsync();
+        var walletId = await CreateWalletAsync(1_000_000m); // funded: a Supply tender may not overdraw the wallet (DR-25)
         var warehouseId = await CreateWarehouseAsync();
         var productId = await CreateProductAsync();
 
@@ -158,7 +158,7 @@ public partial class CreateTransactionTests
         var partnerId = await CreatePartnerAsync();
         await CreateOpenTransactionAsync(partnerId, due: 10_000m, paid: 0m, TransactionType.Supply);
 
-        var walletId = await CreateWalletAsync();
+        var walletId = await CreateWalletAsync(1_000_000m); // funded: a Supply tender may not overdraw the wallet (DR-25)
         var warehouseId = await CreateWarehouseAsync();
         var productId = await CreateProductAsync();
 
@@ -166,6 +166,21 @@ public partial class CreateTransactionTests
             partnerId, productId, warehouseId, due: 5_000m, walletId, paidAmount: 8_000m, OverpaymentHandling.Advance);
 
         // Act + Assert
+        await PostTransactionExpectingBadRequestAsync(request);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldReject_WhenSupplyTenderOverdrawsWallet()
+    {
+        // DR-25: a Supply tender (money out) may not draw more than the wallet holds (parity with negative stock).
+        var partnerId = await CreatePartnerAsync();
+        var walletId = await CreateWalletAsync(5_000m);
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+
+        var request = TransactionRequestFactory.Supply(
+            partnerId, productId, warehouseId, due: 10_000m, walletId, paidAmount: 10_000m);
+
         await PostTransactionExpectingBadRequestAsync(request);
     }
 }


### PR DESCRIPTION
DR-25 backend enforcement (issues-tracker §12).

- One canonical wallet-balance calculator shared by the DTO, the payment form, and the overdraft guards.
- **Fixed the payment-form balance bug** (it summed opening + transfers only, ignoring payment activity — a payment-only wallet showed 0 while the list showed its real negative balance).
- **Overdraft hard-blocked** (400, available-vs-requested) on the standalone-payment, payroll, and Supply/SaleRefund tender paths — parity with the negative-stock block (rule 20), mirroring the existing transfer guard.

Existing payroll/Supply tests that paid from 0-balance wallets are funded to reflect the rule. Suite green except the 3 pre-existing OTP tests.
