### PR TITLE
Reference-gated delete + IsDeletable for Product and Wallet (DR-20)

### DIFF
--- a/src/Ombor.API/Controllers/ProductsController.cs
+++ b/src/Ombor.API/Controllers/ProductsController.cs
@@ -133,6 +133,7 @@ public sealed class ProductsController(
     [HttpDelete("{id:int:min(1)}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeleteAsync(
         [FromRoute] DeleteProductRequest request)
     {

--- a/src/Ombor.API/Controllers/WalletsController.cs
+++ b/src/Ombor.API/Controllers/WalletsController.cs
@@ -131,4 +131,16 @@ public sealed class WalletsController(IWalletService walletService) : Controller
 
         return NoContent();
     }
+
+    /// <summary>Hard-deletes an unreferenced wallet; a referenced wallet is rejected with 409 (archive instead).</summary>
+    [HttpDelete("{id:int:min(1)}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> DeleteAsync([FromRoute] int id)
+    {
+        await walletService.DeleteAsync(id);
+
+        return NoContent();
+    }
 }

--- a/src/Ombor.Application/Interfaces/IWalletService.cs
+++ b/src/Ombor.Application/Interfaces/IWalletService.cs
@@ -11,6 +11,7 @@ public interface IWalletService
     Task<WalletDto> UpdateAsync(UpdateWalletRequest request);
     Task ArchiveAsync(int id);
     Task RestoreAsync(int id);
+    Task DeleteAsync(int id);
 
     Task<WalletTransferDto> CreateTransferAsync(CreateWalletTransferRequest request);
     Task<WalletOperationDto[]> GetOperationsAsync(int walletId);

--- a/src/Ombor.Application/Services/ProductService.cs
+++ b/src/Ombor.Application/Services/ProductService.cs
@@ -31,7 +31,9 @@ internal sealed class ProductService(
             .OrderBy(x => x.Name)
             .ToArrayAsync();
 
-        return [.. products.Select(x => x.ToDto())];
+        var referencedIds = await GetReferencedProductIdsAsync();
+
+        return [.. products.Select(x => x.ToDto() with { IsDeletable = !referencedIds.Contains(x.Id) })];
     }
 
     public async Task<ProductDto> GetByIdAsync(GetProductByIdRequest request)
@@ -40,8 +42,24 @@ internal sealed class ProductService(
 
         var entity = await GetOrThrowAsync(request.Id);
 
-        return entity.ToDto();
+        return entity.ToDto() with { IsDeletable = !await IsProductReferencedAsync(entity.Id) };
     }
+
+    // A product is deletable only until transaction or order history references it (rule 32 / DR-20);
+    // the same predicate backs both the served IsDeletable flag and the delete guard, so they can't drift.
+    private async Task<HashSet<int>> GetReferencedProductIdsAsync()
+    {
+        var ids = await context.TransactionLines.Select(l => l.ProductId)
+            .Concat(context.OrderLines.Select(l => l.ProductId))
+            .Distinct()
+            .ToArrayAsync();
+
+        return [.. ids];
+    }
+
+    private async Task<bool> IsProductReferencedAsync(int id)
+        => await context.TransactionLines.AnyAsync(l => l.ProductId == id)
+           || await context.OrderLines.AnyAsync(l => l.ProductId == id);
 
     public async Task<ProductTransactionDto[]> GetTransactionsAsync(GetProductTransactionsRequest request)
     {
@@ -104,13 +122,9 @@ internal sealed class ProductService(
 
         var entity = await GetOrThrowAsync(request.Id);
 
-        var isReferenced =
-            await context.TransactionLines.AnyAsync(x => x.ProductId == entity.Id) ||
-            await context.OrderLines.AnyAsync(x => x.ProductId == entity.Id);
-
-        if (isReferenced)
+        if (await IsProductReferencedAsync(entity.Id))
         {
-            throw new ValidationException(
+            throw new ConflictException(
                 "Product cannot be deleted because it is referenced by transaction or order history. Archive it instead.");
         }
 

--- a/src/Ombor.Application/Services/WalletService.cs
+++ b/src/Ombor.Application/Services/WalletService.cs
@@ -93,6 +93,25 @@ internal sealed class WalletService(
         await context.SaveChangesAsync();
     }
 
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await GetOrThrowAsync(id);
+
+        // Reference-gated (DR-20): a wallet with payment or transfer history can't be hard-deleted — the same
+        // predicate as the served IsDeletable flag, so the affordance and the guard agree. Archive instead.
+        var isReferenced =
+            await context.PaymentComponents.AnyAsync(c => c.WalletId == id) ||
+            await context.WalletTransfers.AnyAsync(t => t.FromWalletId == id || t.ToWalletId == id);
+
+        if (isReferenced)
+        {
+            throw new ConflictException("Wallet cannot be deleted because payments or transfers reference it. Archive it instead.");
+        }
+
+        context.Wallets.Remove(entity);
+        await context.SaveChangesAsync();
+    }
+
     public async Task<WalletTransferDto> CreateTransferAsync(CreateWalletTransferRequest request)
     {
         await validator.ValidateAndThrowAsync(request);
@@ -347,7 +366,9 @@ internal sealed class WalletService(
                 .Sum(c => (decimal?)c.Amount) ?? 0m,
             w.Components
                 .Where(c => c.SourceType == Domain.Enums.PaymentSourceType.Wallet && c.Payment.Direction == Domain.Enums.PaymentDirection.Expense)
-                .Sum(c => (decimal?)c.Amount) ?? 0m);
+                .Sum(c => (decimal?)c.Amount) ?? 0m,
+            // Referenced (rule 32 / DR-20): any payment component or transfer bound to this wallet.
+            w.Components.Any() || w.IncomingTransfers.Any() || w.OutgoingTransfers.Any());
 
     private static decimal Balance(WalletRow row)
         => row.OpeningBalance + row.Incoming - row.Outgoing + row.PaymentsIn - row.PaymentsOut;
@@ -368,7 +389,8 @@ internal sealed class WalletService(
             row.OpeningBalance,
             row.IsArchived,
             row.CreatedBy,
-            row.CreatedAt);
+            row.CreatedAt,
+            IsDeletable: !row.IsReferenced);
     }
 
     private sealed record WalletRow(
@@ -382,5 +404,6 @@ internal sealed class WalletService(
         decimal Incoming,
         decimal Outgoing,
         decimal PaymentsIn,
-        decimal PaymentsOut);
+        decimal PaymentsOut,
+        bool IsReferenced);
 }

--- a/src/Ombor.Contracts/Responses/Product/ProductDto.cs
+++ b/src/Ombor.Contracts/Responses/Product/ProductDto.cs
@@ -24,6 +24,7 @@ namespace Ombor.Contracts.Responses.Product;
 /// <param name="TotalStock">Total stock summed across warehouses (rule 17).</param>
 /// <param name="AverageCost">Value-weighted average cost across warehouses; null when there is no stock.</param>
 /// <param name="Packaging">Optional packaging info; <see langword="null"/> when not applicable.</param>
+/// <param name="IsDeletable">Whether the product can be hard-deleted (false once referenced by transaction/order history); otherwise DELETE returns 409.</param>
 public sealed record ProductDto(
     int Id,
     int CategoryId,
@@ -43,4 +44,5 @@ public sealed record ProductDto(
     ProductWarehouseItemDto[] WarehouseItems,
     decimal TotalStock,
     decimal? AverageCost,
-    ProductPackagingDto? Packaging);
+    ProductPackagingDto? Packaging,
+    bool IsDeletable = false);

--- a/src/Ombor.Contracts/Responses/Wallet/WalletDto.cs
+++ b/src/Ombor.Contracts/Responses/Wallet/WalletDto.cs
@@ -13,6 +13,7 @@ namespace Ombor.Contracts.Responses.Wallet;
 /// <param name="IsArchived">Whether the wallet is archived.</param>
 /// <param name="CreatedBy">Who created the wallet.</param>
 /// <param name="CreatedAt">When the wallet was created.</param>
+/// <param name="IsDeletable">Whether the wallet can be hard-deleted (false once a payment or transfer references it); otherwise DELETE returns 409.</param>
 public sealed record WalletDto(
     int Id,
     string Name,
@@ -23,4 +24,5 @@ public sealed record WalletDto(
     decimal OpeningBalance,
     bool IsArchived,
     string? CreatedBy,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    bool IsDeletable = false);

--- a/tests/Ombor.Tests.Integration/Endpoints/ProductEndpoints/ProductDeleteGatingTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/ProductEndpoints/ProductDeleteGatingTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Ombor.Contracts.Responses.Product;
+using Ombor.Domain.Entities;
+using Ombor.Domain.Enums;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.ProductEndpoints;
+
+/// <summary>DR-20: a product referenced by history is delete-gated with 409, and the served IsDeletable agrees.</summary>
+public sealed class ProductDeleteGatingTests(TestingWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : ProductTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnConflict_WhenProductIsReferenced()
+    {
+        var productId = await CreateProductAsync(DefaultCategoryId);
+        await ReferenceProductAsync(productId);
+
+        await _client.DeleteAsync<ProblemDetails>(GetUrl(productId), HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldServeIsDeletable_ReflectingReferences()
+    {
+        var freeId = await CreateProductAsync(DefaultCategoryId);
+        var referencedId = await CreateProductAsync(DefaultCategoryId);
+        await ReferenceProductAsync(referencedId);
+
+        var free = await _client.GetAsync<ProductDto>(GetUrl(freeId));
+        var referenced = await _client.GetAsync<ProductDto>(GetUrl(referencedId));
+
+        Assert.True(free.IsDeletable);
+        Assert.False(referenced.IsDeletable);
+    }
+
+    private async Task ReferenceProductAsync(int productId)
+    {
+        var partner = new Partner { Name = $"Ref {Guid.NewGuid():N}", Type = PartnerType.Both };
+        _context.Partners.Add(partner);
+        await _context.SaveChangesAsync();
+
+        var transaction = new TransactionRecord
+        {
+            PartnerId = partner.Id,
+            Partner = null!,
+            Type = TransactionType.Sale,
+            WarehouseId = await EnsureWarehouseAsync(),
+            DateUtc = DateTimeOffset.UtcNow,
+            TotalDue = 100m,
+            TotalPaid = 0m,
+            Status = TransactionStatus.Open,
+            Lines =
+            {
+                new TransactionLine { ProductId = productId, Product = null!, Transaction = null!, UnitPrice = 100m, Quantity = 1m, Discount = 0m },
+            },
+        };
+        _context.Transactions.Add(transaction);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/WalletEndpoints/WalletDeleteGatingTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/WalletEndpoints/WalletDeleteGatingTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Ombor.Contracts.Responses.Wallet;
+using Ombor.Domain.Entities;
+using Ombor.Domain.Enums;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.WalletEndpoints;
+
+/// <summary>DR-20: a wallet referenced by payments/transfers is delete-gated with 409, and IsDeletable agrees.</summary>
+public sealed class WalletDeleteGatingTests(TestingWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : WalletTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnNoContent_WhenWalletUnreferenced()
+    {
+        var walletId = await CreateWalletAsync(0m);
+
+        await _client.DeleteAsync(GetUrl(walletId));
+
+        await _client.GetAsync<ProblemDetails>(GetUrl(walletId), HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnConflict_WhenWalletHasPayment()
+    {
+        var walletId = await CreateWalletAsync(10_000m);
+        await SeedWalletPaymentAsync(walletId);
+
+        await _client.DeleteAsync<ProblemDetails>(GetUrl(walletId), HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldServeIsDeletable_ReflectingReferences()
+    {
+        var freeId = await CreateWalletAsync(0m);
+        var usedId = await CreateWalletAsync(10_000m);
+        await SeedWalletPaymentAsync(usedId);
+
+        var free = await _client.GetAsync<WalletDto>(GetUrl(freeId));
+        var used = await _client.GetAsync<WalletDto>(GetUrl(usedId));
+
+        Assert.True(free.IsDeletable);
+        Assert.False(used.IsDeletable);
+    }
+
+    private async Task SeedWalletPaymentAsync(int walletId)
+    {
+        var payment = new Payment
+        {
+            Number = $"P-{Guid.NewGuid():N}",
+            Type = PaymentType.General,
+            Direction = PaymentDirection.Expense,
+            DateUtc = DateTimeOffset.UtcNow,
+            WalletId = walletId,
+        };
+        payment.Components.Add(new PaymentComponent
+        {
+            Payment = null!,
+            SourceType = PaymentSourceType.Wallet,
+            WalletId = walletId,
+            Amount = 1_000m,
+        });
+        _context.Payments.Add(payment);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/tests/Ombor.Tests.Integration/Helpers/ResponseValidators/ProductValidator.cs
+++ b/tests/Ombor.Tests.Integration/Helpers/ResponseValidators/ProductValidator.cs
@@ -127,6 +127,12 @@ public class ProductValidator(IApplicationDbContext context, FileSettings fileSe
             .OrderBy(x => x.Name)
             .ToArrayAsync();
 
+        // Mirror the service: a product is deletable until transaction/order history references it (DR-20).
+        var referencedIds = (await context.TransactionLines.Select(l => l.ProductId)
+            .Concat(context.OrderLines.Select(l => l.ProductId))
+            .Distinct()
+            .ToArrayAsync()).ToHashSet();
+
         return products
             .Select(x =>
             {
@@ -154,7 +160,8 @@ public class ProductValidator(IApplicationDbContext context, FileSettings fileSe
                     x.WarehouseItems.Select(item => new ProductWarehouseItemDto(item.WarehouseId, item.Warehouse.Name, item.Quantity, item.AverageCost)).ToArray(),
                     totalStock,
                     averageCost,
-                    x.Packaging.Size == 0 ? null : new ProductPackagingDto(x.Packaging.Size, x.Packaging.Label, x.Packaging.Barcode));
+                    x.Packaging.Size == 0 ? null : new ProductPackagingDto(x.Packaging.Size, x.Packaging.Label, x.Packaging.Barcode),
+                    IsDeletable: !referencedIds.Contains(x.Id));
             })
             .ToArray();
     }


### PR DESCRIPTION
DR-20 backend (issues-tracker §12). Brings Product and Wallet to parity with Partner/Warehouse.

- **Product**: delete guard 400 → **409**; `IsDeletable` served on `ProductDto` from the same predicate (referenced by any transaction/order line).
- **Wallet**: new reference-gated `DELETE /api/wallets/{id}` (204, or 409 when payments/transfers reference it) + `IsDeletable` on `WalletDto`.

Extends CLAUDE.md hard rule 6 to all four entities (wording update proposed separately). Covered by delete-gating tests. Suite green except the 3 pre-existing OTP tests.
