### PR TITLE
Serve document number, add line guards, fix over-refund (§12.A)

### DIFF
--- a/src/Ombor.Application/Services/MovementService.cs
+++ b/src/Ombor.Application/Services/MovementService.cs
@@ -104,8 +104,9 @@ internal sealed class MovementService(IApplicationDbContext context) : IMovement
             .ToListAsync();
         foreach (var l in transferLines)
         {
-            movements.Add(new Raw(l.Id, l.DateUtc, MovementKind.Transfer, productId, string.Empty, string.Empty, l.FromWarehouseId, l.FromName, null, null, -l.Quantity));
-            movements.Add(new Raw(l.Id, l.DateUtc, MovementKind.Transfer, productId, string.Empty, string.Empty, l.ToWarehouseId, l.ToName, null, null, l.Quantity));
+            // Each row's counterparty is the other warehouse, so a consumer can link the send and receive rows.
+            movements.Add(new Raw(l.Id, l.DateUtc, MovementKind.Transfer, productId, string.Empty, string.Empty, l.FromWarehouseId, l.FromName, l.ToName, null, -l.Quantity, CounterpartyWarehouseId: l.ToWarehouseId));
+            movements.Add(new Raw(l.Id, l.DateUtc, MovementKind.Transfer, productId, string.Empty, string.Empty, l.ToWarehouseId, l.ToName, l.FromName, null, l.Quantity, CounterpartyWarehouseId: l.FromWarehouseId));
         }
 
         // Running total stock across all warehouses (reconciles to the product's total stock).
@@ -114,7 +115,8 @@ internal sealed class MovementService(IApplicationDbContext context) : IMovement
         return [.. withBalance
             .Select(x => new ProductMovementDto(
                 x.Movement.Id, productId, x.Movement.Date, x.Movement.Kind, x.Movement.WarehouseId,
-                x.Movement.WarehouseName, x.Movement.Quantity, x.Balance))];
+                x.Movement.WarehouseName, x.Movement.CounterpartyWarehouseId, x.Movement.Counterparty,
+                x.Movement.Quantity, x.Balance))];
     }
 
     /// <summary>

--- a/src/Ombor.Application/Services/PartnerService.cs
+++ b/src/Ombor.Application/Services/PartnerService.cs
@@ -112,7 +112,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
 
         var transactions = await context.Transactions
             .Where(t => t.PartnerId == partnerId)
-            .Select(t => new { t.Id, t.DateUtc, t.Type, t.TotalDue, t.TotalPaid, ItemCount = t.Lines.Count })
+            .Select(t => new { t.Id, t.DateUtc, t.Number, t.Type, t.TotalDue, t.TotalPaid, ItemCount = t.Lines.Count })
             .ToArrayAsync();
 
         var payments = await context.Payments
@@ -164,7 +164,8 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
                 : (t.TotalPaid < t.TotalDue ? "partial" : "paid");
 
             // Transactions aren't tied to a single wallet (settled across zero-to-many payments), so no wallet here.
-            events.Add(new(t.Id, type, t.DateUtc, sign * t.TotalDue, t.Id, null, t.ItemCount, status, null, null));
+            // Reference carries the bare document Number (null on synthetic seed rows), mirroring payments below.
+            events.Add(new(t.Id, type, t.DateUtc, sign * t.TotalDue, t.Id, t.Number?.ToString(), t.ItemCount, status, null, null));
         }
 
         foreach (var p in payments)

--- a/src/Ombor.Application/Services/TransactionService.cs
+++ b/src/Ombor.Application/Services/TransactionService.cs
@@ -498,20 +498,27 @@ internal sealed class TransactionService(
             .Select(g => new { ProductId = g.Key, Quantity = g.Sum(l => l.Quantity) })
             .ToDictionaryAsync(x => x.ProductId, x => x.Quantity);
 
-        foreach (var line in request.Lines)
+        // Aggregate this request's lines by product before the cap check. Two lines of the same product in
+        // one request would otherwise each pass against the same persisted baseline while their sum exceeds
+        // the original quantity (over-refund + over-restock). Mirrors the settlement dedup above.
+        var requestedQuantities = request.Lines
+            .GroupBy(l => l.ProductId)
+            .ToDictionary(g => g.Key, g => g.Sum(l => l.Quantity));
+
+        foreach (var (productId, requestedQuantity) in requestedQuantities)
         {
-            if (!originalQuantities.TryGetValue(line.ProductId, out var originalQuantity))
+            if (!originalQuantities.TryGetValue(productId, out var originalQuantity))
             {
                 throw new ValidationException(
-                    $"Product {line.ProductId} is not part of the original transaction.");
+                    $"Product {productId} is not part of the original transaction.");
             }
 
-            alreadyRefunded.TryGetValue(line.ProductId, out var refundedQuantity);
+            alreadyRefunded.TryGetValue(productId, out var refundedQuantity);
 
-            if (refundedQuantity + line.Quantity > originalQuantity)
+            if (refundedQuantity + requestedQuantity > originalQuantity)
             {
                 throw new ValidationException(
-                    $"Refund quantity for product {line.ProductId} exceeds the original transaction quantity.");
+                    $"Refund quantity for product {productId} exceeds the original transaction quantity.");
             }
         }
     }

--- a/src/Ombor.Application/Validators/Transaction/CreateTransactionValidator.cs
+++ b/src/Ombor.Application/Validators/Transaction/CreateTransactionValidator.cs
@@ -19,13 +19,31 @@ public sealed class CreateTransactionValidator : AbstractValidator<CreateTransac
             .NotEmpty()
             .WithMessage("Transaction must contain at least one line item.");
 
-        // Guard each line's discount type: an omitted/0/invalid value would otherwise fail deep in the enum
-        // mapper as a 500. This mirrors the order-line validator and returns a clean 400 instead.
         RuleForEach(x => x.Lines)
-            .ChildRules(line => line
-                .RuleFor(l => l.DiscountType)
-                .IsInEnum()
-                .WithMessage("Invalid discount type."));
+            .ChildRules(line =>
+            {
+                line.RuleFor(l => l.Quantity)
+                    .GreaterThan(0m)
+                    .WithMessage("Transaction line quantity must be greater than zero.");
+
+                // Guard each line's discount type: an omitted/0/invalid value would otherwise fail deep in
+                // the enum mapper as a 500. This mirrors the order-line validator and returns a clean 400.
+                line.RuleFor(l => l.DiscountType)
+                    .IsInEnum()
+                    .WithMessage("Invalid discount type.");
+
+                // Rule 37 clamps only positive discounts, so a negative value would act as a surcharge that
+                // inflates TotalDue; a percentage above 100 is nonsensical. Reject both with a 400 rather
+                // than silently clamping. (Discount is a non-nullable decimal here, so the floor is unconditional.)
+                line.RuleFor(l => l.Discount)
+                    .GreaterThanOrEqualTo(0m)
+                    .WithMessage("Discount cannot be negative.");
+
+                line.RuleFor(l => l.Discount)
+                    .LessThanOrEqualTo(100m)
+                    .When(l => l.DiscountType == Contracts.Enums.DiscountType.Percentage)
+                    .WithMessage("A percentage discount cannot exceed 100.");
+            });
 
         RuleFor(x => x.PaidAmount)
             .GreaterThanOrEqualTo(0m)

--- a/src/Ombor.Contracts/Responses/Partner/PartnerLedgerEntryDto.cs
+++ b/src/Ombor.Contracts/Responses/Partner/PartnerLedgerEntryDto.cs
@@ -14,7 +14,7 @@ namespace Ombor.Contracts.Responses.Partner;
 /// the payment id for payment/deposit/withdraw rows, and null for the opening event.
 /// <see cref="Type"/> tells the frontend which kind it is.
 /// </param>
-/// <param name="Reference">The document number of the underlying payment, if any.</param>
+/// <param name="Reference">The bare document number of the underlying record — the transaction number for sale/supply/refund-* rows and the payment number for payment/deposit/withdraw rows; null for the opening event and for records without a persisted number (synthetic seed rows).</param>
 /// <param name="ItemCount">Number of line items, for transaction events.</param>
 /// <param name="Status">Settlement status for transaction events (paid, partial, unpaid) or "done".</param>
 /// <param name="WalletName">The wallet the money moved through, for payment events (payment, deposit, withdraw); null otherwise.</param>

--- a/src/Ombor.Contracts/Responses/Product/ProductMovementDto.cs
+++ b/src/Ombor.Contracts/Responses/Product/ProductMovementDto.cs
@@ -11,6 +11,8 @@ namespace Ombor.Contracts.Responses.Product;
 /// <param name="Kind">The specific event type the movement came from — sourced from the underlying event, not the stock direction.</param>
 /// <param name="WarehouseId">The warehouse the movement happened in.</param>
 /// <param name="WarehouseName">The warehouse name.</param>
+/// <param name="CounterpartyWarehouseId">For a transfer row, the id of the other warehouse (the deep-link target that ties the transfer's send and receive rows together); otherwise null.</param>
+/// <param name="CounterpartyWarehouseName">For a transfer row, the name of the other warehouse; otherwise null.</param>
 /// <param name="Quantity">The signed quantity delta (positive = in, negative = out).</param>
 /// <param name="BalanceAfter">The product's total stock across all warehouses after the movement.</param>
 public sealed record ProductMovementDto(
@@ -20,5 +22,7 @@ public sealed record ProductMovementDto(
     MovementKind Kind,
     int WarehouseId,
     string WarehouseName,
+    int? CounterpartyWarehouseId,
+    string? CounterpartyWarehouseName,
     decimal Quantity,
     decimal BalanceAfter);

--- a/tests/Ombor.Tests.Integration/Endpoints/MovementEndpoints/MovementLedgerTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/MovementEndpoints/MovementLedgerTests.cs
@@ -114,6 +114,12 @@ public sealed class MovementLedgerTests(TestingWebApplicationFactory factory, IT
         Assert.Equal(30, receive.Quantity);
         Assert.False(string.IsNullOrEmpty(receive.WarehouseName));
 
+        // Each transfer row names the other warehouse so a consumer can link the two sides.
+        Assert.Equal(destination, send.CounterpartyWarehouseId);
+        Assert.Equal(source, receive.CounterpartyWarehouseId);
+        Assert.False(string.IsNullOrEmpty(send.CounterpartyWarehouseName));
+        Assert.False(string.IsNullOrEmpty(receive.CounterpartyWarehouseName));
+
         // The running total reconciles to the product's total stock across warehouses.
         var totalStock = await _context.WarehouseItems.AsNoTracking()
             .Where(i => i.ProductId == product)

--- a/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerLedgerTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerLedgerTests.cs
@@ -47,6 +47,22 @@ public sealed class PartnerLedgerTests(TestingWebApplicationFactory factory, ITe
     }
 
     [Fact]
+    public async Task Ledger_ShouldExposeTransactionNumber_AsReferenceOnTransactionRows()
+    {
+        // Arrange — a sale carrying a persisted document number (F20). Opening balance 0 keeps this focused.
+        var partnerId = await CreateLedgerPartnerAsync(openingBalance: 0m);
+        await CreateOpenTransactionAsync(partnerId, TransactionType.Sale, due: 5_000m, paid: 0m, number: 797);
+
+        // Act
+        var ledger = await _client.GetAsync<PartnerLedgerEntryDto[]>($"{GetUrl(partnerId)}/ledger");
+
+        // Assert — the sale row serves the bare transaction number; the opening row has no reference.
+        var sale = ledger.Single(e => e.Type == "sale");
+        Assert.Equal("797", sale.Reference);
+        Assert.Null(ledger.Single(e => e.Type == "opening").Reference);
+    }
+
+    [Fact]
     public async Task Delete_ShouldReturnConflict_WhenPartnerIsReferenced()
     {
         // Arrange — a partner with a transaction can't be hard-deleted.
@@ -84,13 +100,14 @@ public sealed class PartnerLedgerTests(TestingWebApplicationFactory factory, ITe
         return partner.Id;
     }
 
-    private async Task<int> CreateOpenTransactionAsync(int partnerId, TransactionType type, decimal due, decimal paid)
+    private async Task<int> CreateOpenTransactionAsync(int partnerId, TransactionType type, decimal due, decimal paid, int? number = null)
     {
         var transaction = new TransactionRecord
         {
             PartnerId = partnerId,
             Partner = null!,
             Type = type,
+            Number = number,
             WarehouseId = await EnsureWarehouseAsync(),
             DateUtc = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
             TotalDue = due,

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Refund.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Refund.cs
@@ -1,0 +1,75 @@
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Transaction;
+
+namespace Ombor.Tests.Integration.Endpoints.Transactions;
+
+public partial class CreateTransactionTests
+{
+    // Rule 5: cumulative refunded quantity per original line must not exceed the original quantity. The guard
+    // must aggregate the request's own lines — two lines of the same product each pass against the same
+    // baseline, so without pre-grouping their sum over-refunds.
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectRefund_WhenDuplicateProductLinesExceedOriginalQuantity()
+    {
+        // Arrange — a Sale of 10 units.
+        var partnerId = await CreatePartnerAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        var sale = await PostTransactionAsync(BuildSale(partnerId, productId, warehouseId, quantity: 10m));
+
+        // A SaleRefund naming the same product twice at 6 + 6 = 12 > 10. Each line passes 0+6 <= 10 on its own.
+        var refund = BuildRefund(partnerId, productId, warehouseId, sale.Id, quantities: [6m, 6m]);
+
+        // Act + Assert — must be a clean 400, no over-refund / over-restock.
+        await PostTransactionExpectingBadRequestAsync(refund);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldAcceptRefund_WhenDuplicateProductLinesSumWithinOriginalQuantity()
+    {
+        // Arrange — a Sale of 10 units.
+        var partnerId = await CreatePartnerAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        var sale = await PostTransactionAsync(BuildSale(partnerId, productId, warehouseId, quantity: 10m));
+
+        // Same product split across two lines summing to exactly the original quantity (6 + 4 = 10).
+        var refund = BuildRefund(partnerId, productId, warehouseId, sale.Id, quantities: [6m, 4m]);
+
+        // Act + Assert — the grouping must sum lines, not reject a legitimate split.
+        await PostTransactionAsync(refund);
+    }
+
+    private static CreateTransactionRequest BuildSale(int partnerId, int productId, int warehouseId, decimal quantity)
+        => new(
+            PartnerId: partnerId,
+            Type: TransactionType.Sale,
+            Notes: null,
+            Lines: [new CreateTransactionLine(productId, UnitPrice: 1_000m, Discount: 0m, DiscountType.Percentage, quantity)],
+            WalletId: null,
+            PaidAmount: 0m,
+            Settlements: null,
+            Overpayment: OverpaymentHandling.Change,
+            Attachments: null!,
+            WarehouseId: warehouseId);
+
+    private static CreateTransactionRequest BuildRefund(int partnerId, int productId, int warehouseId, int originalTransactionId, decimal[] quantities)
+        => new(
+            PartnerId: partnerId,
+            Type: TransactionType.SaleRefund,
+            Notes: null,
+            Lines: [.. quantities.Select(q => new CreateTransactionLine(productId, UnitPrice: 1_000m, Discount: 0m, DiscountType.Percentage, q))],
+            WalletId: null,
+            PaidAmount: 0m,
+            Settlements: null,
+            Overpayment: OverpaymentHandling.Change,
+            Attachments: null!,
+            WarehouseId: warehouseId,
+            OriginalTransactionId: originalTransactionId,
+            RefundReason: "Returned");
+}

--- a/tests/Ombor.Tests.Unit/Validators/CreateTransactionValidatorTests.cs
+++ b/tests/Ombor.Tests.Unit/Validators/CreateTransactionValidatorTests.cs
@@ -24,11 +24,67 @@ public sealed class CreateTransactionValidatorTests
         Assert.Equal(expectedValid, result.IsValid);
     }
 
-    private static CreateTransactionRequest NewRequest(DiscountType discountType) => new(
+    [Theory]
+    [InlineData(1.0, true)]
+    [InlineData(0.5, true)]     // fractional base units are valid (decimal quantity)
+    [InlineData(0.0, false)]
+    [InlineData(-1.0, false)]
+    public void LineQuantity_MustBeGreaterThanZero(double quantity, bool expectedValid)
+    {
+        var request = NewRequest(quantity: (decimal)quantity);
+
+        var result = _validator.Validate(request);
+
+        Assert.Equal(expectedValid, result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(50.0, true)]
+    [InlineData(-0.01, false)]  // a negative discount would act as a surcharge (rule 37 only clamps positive)
+    [InlineData(-100.0, false)]
+    public void LineDiscount_CannotBeNegative(double discount, bool expectedValid)
+    {
+        var request = NewRequest(DiscountType.Fixed, discount: (decimal)discount);
+
+        var result = _validator.Validate(request);
+
+        Assert.Equal(expectedValid, result.IsValid);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(100.0, true)]
+    [InlineData(100.01, false)]
+    [InlineData(150.0, false)]
+    public void LinePercentageDiscount_CannotExceed100(double discount, bool expectedValid)
+    {
+        var request = NewRequest(DiscountType.Percentage, discount: (decimal)discount);
+
+        var result = _validator.Validate(request);
+
+        Assert.Equal(expectedValid, result.IsValid);
+    }
+
+    [Fact]
+    public void LineFixedDiscount_MayExceed100()
+    {
+        // The <= 100 cap is percentage-only; a fixed discount is a currency amount clamped by the line total (rule 37).
+        var request = NewRequest(DiscountType.Fixed, discount: 5_000m);
+
+        var result = _validator.Validate(request);
+
+        Assert.True(result.IsValid);
+    }
+
+    private static CreateTransactionRequest NewRequest(
+        DiscountType discountType = DiscountType.Percentage,
+        decimal quantity = 1m,
+        decimal discount = 0m) => new(
         PartnerId: 1,
         Type: TransactionType.Sale,
         Notes: null,
-        Lines: [new CreateTransactionLine(ProductId: 1, UnitPrice: 1_000m, Discount: 0m, discountType, Quantity: 1m)],
+        Lines: [new CreateTransactionLine(ProductId: 1, UnitPrice: 1_000m, Discount: discount, discountType, Quantity: quantity)],
         WalletId: null,
         PaidAmount: 0m,
         Settlements: null,


### PR DESCRIPTION
Executes the migration-free correctness & serving items from the backend queue (`Ombor.Docs/issues-tracker.md` §12.A). Off `redesign/issue-fixes`.

- **F20 — partner-ledger `reference`:** `PartnerService.GetLedgerAsync` now serves the bare transaction `Number` as `reference` on sale/supply/refund rows (was `null`, so the FE «Номер» column showed «—»). No migration, no DTO-shape change; broadened the DTO doc-comment.
- **Transaction-line guards:** `CreateTransactionValidator` now rejects `Quantity ≤ 0`, `Discount < 0`, and a Percentage `Discount > 100` (clean 400 instead of a surcharge / silent clamp). All three per owner ruling.
- **Intra-request over-refund (backend-gaps F1):** `ValidateRefundOrThrowAsync` now pre-groups request lines by `ProductId` before the rule-5 cap, so two lines of the same product can't collectively exceed the original quantity.
- **`ProductMovementDto` counterparty:** transfer rows now carry the counterparty warehouse so the two sides link (mirrors the warehouse ledger).

**Tests:** unit (validator guards) + integration (ledger reference, over-refund reject/accept, movement counterparty). Full integration suite green (259/262; the 3 `PasswordResetTests` OTP failures are the pre-existing baseline).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product transfer movements now show the counterparty warehouse name and ID.
  * Partner ledger transaction entries now include the related document number as a reference.

* **Bug Fixes**
  * Refunds with duplicate product lines are now validated using their combined quantity.
  * Transaction creation now rejects negative discounts, percentage discounts above 100%, and invalid discount types earlier.

* **Tests**
  * Added coverage for transfer links, ledger references, refund limits, and discount validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->