### PR TITLE
Persist package entry on transaction lines and template items (F21)

### DIFF
--- a/src/Ombor.Application/Extensions/ProductPackagingExtensions.cs
+++ b/src/Ombor.Application/Extensions/ProductPackagingExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Ombor.Application.Interfaces;
+
+namespace Ombor.Application.Extensions;
+
+internal static class ProductPackagingExtensions
+{
+    /// <summary>
+    /// Loads the configured package size (base units per package) for each of the given products, so a
+    /// package-entry line can be resolved to its base-unit quantity server-side (rule 21). Returns an empty
+    /// map when there are no product ids.
+    /// </summary>
+    public static async Task<IReadOnlyDictionary<int, int>> LoadPackageSizesAsync(
+        this IApplicationDbContext context, IEnumerable<int> productIds)
+    {
+        var ids = productIds.Distinct().ToArray();
+
+        if (ids.Length == 0)
+        {
+            return new Dictionary<int, int>();
+        }
+
+        return await context.Products
+            .Where(p => ids.Contains(p.Id))
+            .Select(p => new { p.Id, p.Packaging.Size })
+            .ToDictionaryAsync(x => x.Id, x => x.Size);
+    }
+}

--- a/src/Ombor.Application/Mappings/PackageEntry.cs
+++ b/src/Ombor.Application/Mappings/PackageEntry.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+namespace Ombor.Application.Mappings;
+
+/// <summary>
+/// Resolves a transaction line / template item entered in packages into its base-unit quantity and the
+/// package-size snapshot (rule 21). The package size is authoritative on the product, never supplied by the
+/// client, so the base quantity is computed server-side: <c>pack count × size</c>. A base-unit entry (no pack
+/// count) passes its quantity through unchanged with a null snapshot.
+/// </summary>
+internal static class PackageEntry
+{
+    /// <param name="productId">The line's product.</param>
+    /// <param name="requestQuantity">The base-unit quantity from the request (used only for a base-unit entry).</param>
+    /// <param name="packageQuantity">The entered pack count, or null for a base-unit entry.</param>
+    /// <param name="packageSizes">Product id → configured package size, for the package-entry products.</param>
+    /// <returns>The base-unit quantity to persist and the package-size snapshot (null for a base-unit entry).</returns>
+    public static (decimal Quantity, int? PackageSize) Resolve(
+        int productId,
+        decimal requestQuantity,
+        int? packageQuantity,
+        IReadOnlyDictionary<int, int> packageSizes)
+    {
+        if (packageQuantity is not int count || count <= 0)
+        {
+            return (requestQuantity, null);
+        }
+
+        if (!packageSizes.TryGetValue(productId, out var size) || size <= 0)
+        {
+            throw new ValidationException(
+                $"Product {productId} has no configured package size and cannot be entered in packages.");
+        }
+
+        return (count * size, size);
+    }
+}

--- a/src/Ombor.Application/Mappings/TemplateMappings.cs
+++ b/src/Ombor.Application/Mappings/TemplateMappings.cs
@@ -68,7 +68,7 @@ internal static class TemplateMappings
             Items: items);
     }
 
-    public static void ApplyUpdate(this Template template, UpdateTemplateRequest request)
+    public static void ApplyUpdate(this Template template, UpdateTemplateRequest request, IReadOnlyDictionary<int, int> packageSizes)
     {
         template.Name = request.Name;
         template.PartnerId = request.PartnerId;
@@ -80,13 +80,17 @@ internal static class TemplateMappings
 
         foreach (var requestItem in request.Items)
         {
+            // A package-entry item resolves to base units server-side; the package size is snapshotted (rule 21).
+            var (quantity, packageSize) = PackageEntry.Resolve(requestItem.ProductId, requestItem.Quantity, requestItem.PackageQuantity, packageSizes);
+
             if (requestItem.Id != 0 && existingById.TryGetValue(requestItem.Id, out var existing))
             {
                 existing.ProductId = requestItem.ProductId;
-                existing.Quantity = requestItem.Quantity;
+                existing.Quantity = quantity;
                 existing.UnitPrice = requestItem.UnitPrice;
                 existing.DiscountAmount = requestItem.Discount;
                 existing.DiscountType = requestItem.DiscountType.ToDomainDiscountType();
+                existing.PackageSize = packageSize;
                 keptIds.Add(existing.Id);
             }
             else
@@ -95,10 +99,11 @@ internal static class TemplateMappings
                 template.Items.Add(new TemplateItem
                 {
                     ProductId = requestItem.ProductId,
-                    Quantity = requestItem.Quantity,
+                    Quantity = quantity,
                     UnitPrice = requestItem.UnitPrice,
                     DiscountAmount = requestItem.Discount,
                     DiscountType = requestItem.DiscountType.ToDomainDiscountType(),
+                    PackageSize = packageSize,
                     Product = null!,
                     Template = null!,
                 });
@@ -111,10 +116,10 @@ internal static class TemplateMappings
         }
     }
 
-    public static Template ToEntity(this CreateTemplateRequest request)
+    public static Template ToEntity(this CreateTemplateRequest request, IReadOnlyDictionary<int, int> packageSizes)
     {
         var items = request.Items
-            .Select(ToEntity)
+            .Select(item => item.ToEntity(packageSizes))
             .ToList();
 
         return new Template
@@ -127,30 +132,23 @@ internal static class TemplateMappings
         };
     }
 
-    private static TemplateItem ToEntity(this CreateTemplateItem item)
-        => new()
-        {
-            ProductId = item.ProductId,
-            Quantity = item.Quantity,
-            UnitPrice = item.UnitPrice,
-            DiscountAmount = item.Discount,
-            DiscountType = item.DiscountType.ToDomainDiscountType(),
-            Product = null!, // Will be set by EF
-            Template = null! // Will be set by EF
-        };
+    private static TemplateItem ToEntity(this CreateTemplateItem item, IReadOnlyDictionary<int, int> packageSizes)
+    {
+        // A package-entry item resolves to base units server-side; the package size is snapshotted (rule 21).
+        var (quantity, packageSize) = PackageEntry.Resolve(item.ProductId, item.Quantity, item.PackageQuantity, packageSizes);
 
-    private static TemplateItem ToEntity(this UpdateTemplateItem item)
-        => new()
+        return new()
         {
-            Id = item.Id,
             ProductId = item.ProductId,
-            Quantity = item.Quantity,
+            Quantity = quantity,
             UnitPrice = item.UnitPrice,
             DiscountAmount = item.Discount,
             DiscountType = item.DiscountType.ToDomainDiscountType(),
+            PackageSize = packageSize,
             Product = null!, // Will be set by EF
             Template = null! // Will be set by EF
         };
+    }
 
     private static TemplateItemDto ToDto(this TemplateItem item)
     {
@@ -175,7 +173,8 @@ internal static class TemplateMappings
             Quantity: item.Quantity,
             UnitPrice: item.UnitPrice,
             Discount: item.DiscountAmount,
-            DiscountType: item.DiscountType.ToString());
+            DiscountType: item.DiscountType.ToString(),
+            PackageSize: item.PackageSize);
     }
 
     public static TemplateType ToDomain(this Contracts.Enums.TemplateType type)

--- a/src/Ombor.Application/Mappings/TransactionMapper.cs
+++ b/src/Ombor.Application/Mappings/TransactionMapper.cs
@@ -7,23 +7,30 @@ namespace Ombor.Application.Mappings;
 
 internal interface ITransactionMapper
 {
-    TransactionRecord ToEntity(CreateTransactionRequest request);
+    TransactionRecord ToEntity(CreateTransactionRequest request, IReadOnlyDictionary<int, int> packageSizes);
     TransactionDto ToDto(TransactionRecord transaction);
 }
 
 internal sealed class TransactionMapper : ITransactionMapper
 {
-    public TransactionRecord ToEntity(CreateTransactionRequest request)
+    public TransactionRecord ToEntity(CreateTransactionRequest request, IReadOnlyDictionary<int, int> packageSizes)
     {
-        var lines = request.Lines.Select(x => new TransactionLine
+        var lines = request.Lines.Select(x =>
         {
-            ProductId = x.ProductId,
-            UnitPrice = x.UnitPrice,
-            Discount = x.Discount,
-            DiscountType = x.DiscountType.ToDomainDiscountType(),
-            Quantity = x.Quantity,
-            Product = null!,
-            Transaction = null!
+            // A package-entry line resolves to base units server-side (rule 21); the package size is snapshotted.
+            var (quantity, packageSize) = PackageEntry.Resolve(x.ProductId, x.Quantity, x.PackageQuantity, packageSizes);
+
+            return new TransactionLine
+            {
+                ProductId = x.ProductId,
+                UnitPrice = x.UnitPrice,
+                Discount = x.Discount,
+                DiscountType = x.DiscountType.ToDomainDiscountType(),
+                Quantity = quantity,
+                PackageSize = packageSize,
+                Product = null!,
+                Transaction = null!
+            };
         }).ToArray();
 
         return new TransactionRecord
@@ -61,7 +68,7 @@ internal sealed class TransactionMapper : ITransactionMapper
             transaction.TotalDue,
             transaction.TotalPaid,
             transaction.Lines.Select(
-                x => new TransactionLineDto(x.Id, x.ProductId, x.Product.Name, x.TransactionId, x.UnitPrice, x.Discount, x.DiscountType.ToString(), x.Quantity, x.Total)),
+                x => new TransactionLineDto(x.Id, x.ProductId, x.Product.Name, x.TransactionId, x.UnitPrice, x.Discount, x.DiscountType.ToString(), x.Quantity, x.Total, x.PackageSize)),
             transaction.OriginalTransactionId,
             transaction.OriginalTransaction?.Number.ToString(),
             transaction.RefundReason);

--- a/src/Ombor.Application/Services/TemplateService.cs
+++ b/src/Ombor.Application/Services/TemplateService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Ombor.Application.Extensions;
 using Ombor.Application.Interfaces;
 using Ombor.Application.Mappings;
 using Ombor.Contracts.Requests.Template;
@@ -35,7 +36,11 @@ internal sealed class TemplateService(IApplicationDbContext context, IRequestVal
     {
         await validator.ValidateAndThrowAsync(request);
 
-        var entity = request.ToEntity();
+        // Package-entry items are resolved to base units server-side from the product's package size (rule 21).
+        var packageSizes = await context.LoadPackageSizesAsync(
+            request.Items.Where(i => i.PackageQuantity is > 0).Select(i => i.ProductId));
+
+        var entity = request.ToEntity(packageSizes);
 
         context.Templates.Add(entity);
         await context.SaveChangesAsync();
@@ -56,7 +61,11 @@ internal sealed class TemplateService(IApplicationDbContext context, IRequestVal
             .FirstOrDefaultAsync(x => x.Id == request.Id)
             ?? throw new EntityNotFoundException<Template>(request.Id);
 
-        template.ApplyUpdate(request);
+        // Package-entry items are resolved to base units server-side from the product's package size (rule 21).
+        var packageSizes = await context.LoadPackageSizesAsync(
+            request.Items.Where(i => i.PackageQuantity is > 0).Select(i => i.ProductId));
+
+        template.ApplyUpdate(request, packageSizes);
 
         await context.SaveChangesAsync();
 

--- a/src/Ombor.Application/Services/TransactionService.cs
+++ b/src/Ombor.Application/Services/TransactionService.cs
@@ -46,7 +46,7 @@ internal sealed class TransactionService(
                 x.DateUtc,
                 x.TotalDue,
                 x.TotalPaid,
-                Lines = x.Lines.Select(l => new TransactionLineDto(l.Id, l.ProductId, l.Product.Name, l.TransactionId, l.UnitPrice, l.Discount, l.DiscountType.ToString(), l.Quantity, l.Total)).ToArray(),
+                Lines = x.Lines.Select(l => new TransactionLineDto(l.Id, l.ProductId, l.Product.Name, l.TransactionId, l.UnitPrice, l.Discount, l.DiscountType.ToString(), l.Quantity, l.Total, l.PackageSize)).ToArray(),
                 x.OriginalTransactionId,
                 OriginalNumber = x.OriginalTransaction != null ? x.OriginalTransaction.Number : null,
                 x.RefundReason,
@@ -121,7 +121,7 @@ internal sealed class TransactionService(
                     .ToArray(),
                 Lines = t.Lines.Select(l => new TransactionLineDto(
                     l.Id, l.ProductId, l.Product.Name, l.TransactionId,
-                    l.UnitPrice, l.Discount, l.DiscountType.ToString(), l.Quantity, l.Total)).ToArray(),
+                    l.UnitPrice, l.Discount, l.DiscountType.ToString(), l.Quantity, l.Total, l.PackageSize)).ToArray(),
                 // Settling allocations only (rule 10), newest-first — same shape as GET /{id}/payments.
                 Payments = t.PaymentAllocations
                     .Where(a => a.Type == PaymentAllocationType.TransactionSettlement)
@@ -170,7 +170,11 @@ internal sealed class TransactionService(
     {
         await ValidateOrThrowAsync(request);
 
-        var transactionEntity = mapper.ToEntity(request);
+        // Package-entry lines are resolved to base units server-side from the product's package size (rule 21).
+        var packageSizes = await context.LoadPackageSizesAsync(
+            request.Lines.Where(l => l.PackageQuantity is > 0).Select(l => l.ProductId));
+
+        var transactionEntity = mapper.ToEntity(request, packageSizes);
         transactionEntity.CreatedById = currentUser.UserId;
         var partner = await context.Partners.FindAsync(request.PartnerId)
                 ?? throw new InvalidOperationException($"Partner {request.PartnerId} not found");
@@ -181,7 +185,8 @@ internal sealed class TransactionService(
             await context.MoveStockAsync(
                 request.WarehouseId!.Value,
                 request.Type.ToDomainType().ToStockMovement(),
-                request.Lines.Select(l => (l.ProductId, l.Quantity, l.UnitPrice)));
+                // Use the resolved entity lines so a package-entry line moves its base-unit quantity, not the raw request value.
+                transactionEntity.Lines.Select(l => (l.ProductId, l.Quantity, l.UnitPrice)));
             transactionEntity.Number = await allocator.AllocateAsync(NumberSeriesType.Transaction);
             context.Transactions.Add(transactionEntity);
             await AddAttachmentsAsync(request, transactionEntity);

--- a/src/Ombor.Contracts/Requests/Template/CreateTemplateRequest.cs
+++ b/src/Ombor.Contracts/Requests/Template/CreateTemplateRequest.cs
@@ -13,4 +13,5 @@ public sealed record CreateTemplateItem(
     decimal Quantity,
     decimal UnitPrice,
     decimal Discount,
-    DiscountType DiscountType = DiscountType.Fixed);
+    DiscountType DiscountType = DiscountType.Fixed,
+    int? PackageQuantity = null);

--- a/src/Ombor.Contracts/Requests/Template/UpdateTemplateRequest.cs
+++ b/src/Ombor.Contracts/Requests/Template/UpdateTemplateRequest.cs
@@ -15,4 +15,5 @@ public sealed record UpdateTemplateItem(
     decimal Quantity,
     decimal UnitPrice,
     decimal Discount,
-    DiscountType DiscountType = DiscountType.Fixed);
+    DiscountType DiscountType = DiscountType.Fixed,
+    int? PackageQuantity = null);

--- a/src/Ombor.Contracts/Requests/Transaction/CreateTransactionRequest.cs
+++ b/src/Ombor.Contracts/Requests/Transaction/CreateTransactionRequest.cs
@@ -43,10 +43,12 @@ public sealed record CreateTransactionRequest(
 /// <param name="UnitPrice">Price per unit.</param>
 /// <param name="Discount">Discount value, interpreted per <paramref name="DiscountType"/> (rule 37).</param>
 /// <param name="DiscountType">Whether <paramref name="Discount"/> is a percentage or a fixed amount.</param>
-/// <param name="Quantity">Quantity.</param>
+/// <param name="Quantity">Quantity in base units. Ignored for a package entry (see <paramref name="PackageQuantity"/>), where the server computes the base quantity instead.</param>
+/// <param name="PackageQuantity">The number of packages entered, for a package-entry line; null for a base-unit line. The server reads the product's package size, computes the base <paramref name="Quantity"/>, and snapshots the size (rule 21). The package size is never supplied by the client.</param>
 public sealed record CreateTransactionLine(
     int ProductId,
     decimal UnitPrice,
     decimal Discount,
     DiscountType DiscountType,
-    decimal Quantity);
+    decimal Quantity,
+    int? PackageQuantity = null);

--- a/src/Ombor.Contracts/Responses/Template/TemplateItemDto.cs
+++ b/src/Ombor.Contracts/Responses/Template/TemplateItemDto.cs
@@ -12,6 +12,7 @@ namespace Ombor.Contracts.Responses.Template;
 /// <param name="UnitPrice">The unit price.</param>
 /// <param name="Discount">The discount value, interpreted per <paramref name="DiscountType"/>.</param>
 /// <param name="DiscountType">Whether <paramref name="Discount"/> is a Percentage or a Fixed amount (rule 37).</param>
+/// <param name="PackageSize">When the item was entered in packages, the package size (base units per package) at entry time; null for a base-unit item. The entered pack count is <paramref name="Quantity"/> ÷ this value (rule 21).</param>
 public sealed record TemplateItemDto(
     int Id,
     int ProductId,
@@ -23,4 +24,5 @@ public sealed record TemplateItemDto(
     decimal Quantity,
     decimal UnitPrice,
     decimal Discount,
-    string DiscountType);
+    string DiscountType,
+    int? PackageSize = null);

--- a/src/Ombor.Contracts/Responses/Transaction/TransactionDto.cs
+++ b/src/Ombor.Contracts/Responses/Transaction/TransactionDto.cs
@@ -31,6 +31,8 @@ public sealed record TransactionDto(
     string? OriginalTransactionNumber = null,
     string? RefundReason = null);
 
+/// <summary>A single line of a transaction (shared by the list and detail views).</summary>
+/// <param name="PackageSize">When the line was entered in packages, the package size (base units per package) at entry time; null for a base-unit line. The entered pack count is <paramref name="Quantity"/> ÷ this value; <paramref name="Quantity"/> (base units) stays authoritative (rule 21).</param>
 public sealed record TransactionLineDto(
     int Id,
     int ProductId,
@@ -40,4 +42,5 @@ public sealed record TransactionLineDto(
     decimal Discount,
     string DiscountType,
     decimal Quantity,
-    decimal Total);
+    decimal Total,
+    int? PackageSize = null);

--- a/src/Ombor.Domain/Entities/TemplateItem.cs
+++ b/src/Ombor.Domain/Entities/TemplateItem.cs
@@ -16,6 +16,14 @@ public class TemplateItem : AuditableEntity, IOrganizationScoped
     public decimal Quantity { get; set; }
 
     /// <summary>
+    /// When the item was entered in packages, the package size (base units per package) snapshotted from the
+    /// product at event time; null when entered in base units. Audit-only (rule 21): <see cref="Quantity"/>
+    /// (base units) is server-computed as <c>pack count × PackageSize</c>; the pack count is recoverable as
+    /// <c>Quantity / PackageSize</c> and is not stored separately.
+    /// </summary>
+    public int? PackageSize { get; set; }
+
+    /// <summary>
     /// Gets or sets unit price of the <see cref="TemplateItem"/>.
     /// </summary>
     public decimal UnitPrice { get; set; }

--- a/src/Ombor.Domain/Entities/TransactionLine.cs
+++ b/src/Ombor.Domain/Entities/TransactionLine.cs
@@ -19,6 +19,15 @@ public class TransactionLine : EntityBase, IOrganizationScoped
     public decimal Quantity { get; set; }
 
     /// <summary>
+    /// When the line was entered in packages, the package size (base units per package) snapshotted from the
+    /// product at event time; null when entered in base units. Audit-only (rule 21): <see cref="Quantity"/>
+    /// (base units) is server-computed as <c>pack count × PackageSize</c> and stays the source of truth for
+    /// stock and WAC. The entered pack count is recoverable as <c>Quantity / PackageSize</c>, so it is not
+    /// stored separately. Snapshotted so a later change to the product's packaging cannot rewrite this record.
+    /// </summary>
+    public int? PackageSize { get; set; }
+
+    /// <summary>
     /// Line total after discount (rule 37). A <see cref="DiscountType.Percentage"/> discount is
     /// <c>gross × discount / 100</c>; a <see cref="DiscountType.Fixed"/> discount is the value itself.
     /// The discount is clamped to the line gross so a total never goes negative. Kept as a single

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719112703_Add_Line_Package_Size.Designer.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719112703_Add_Line_Package_Size.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombor.Infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using Ombor.Infrastructure.Persistence;
 namespace Ombor.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719112703_Add_Line_Package_Size")]
+    partial class Add_Line_Package_Size
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719112703_Add_Line_Package_Size.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719112703_Add_Line_Package_Size.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombor.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Line_Package_Size : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PackageSize",
+                table: "TransactionLine",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PackageSize",
+                table: "TemplateItem",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PackageSize",
+                table: "TransactionLine");
+
+            migrationBuilder.DropColumn(
+                name: "PackageSize",
+                table: "TemplateItem");
+        }
+    }
+}

--- a/tests/Ombor.Tests.Common/Extensions/RequestExtensions.cs
+++ b/tests/Ombor.Tests.Common/Extensions/RequestExtensions.cs
@@ -178,6 +178,9 @@ public static class RequestExtensions
             content.Add(new StringContent(l.Discount.ToString(cultureInfo)), $"Lines[{i}].Discount");
             content.Add(new StringContent(((int)l.DiscountType).ToString()), $"Lines[{i}].DiscountType");
             content.Add(new StringContent(l.Quantity.ToString(cultureInfo)), $"Lines[{i}].Quantity");
+
+            if (l.PackageQuantity.HasValue)
+                content.Add(new StringContent(l.PackageQuantity.Value.ToString()), $"Lines[{i}].PackageQuantity");
         }
 
         // Settlements of other open transactions (optional)

--- a/tests/Ombor.Tests.Integration/Endpoints/TemplateEndpoints/TemplatePackEntryTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/TemplateEndpoints/TemplatePackEntryTests.cs
@@ -1,0 +1,70 @@
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Template;
+using Ombor.Contracts.Responses.Template;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.TemplateEndpoints;
+
+public sealed class TemplatePackEntryTests(
+    TestingWebApplicationFactory factory,
+    ITestOutputHelper outputHelper) : TemplateTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task PostThenGet_ShouldComputeBaseQuantityFromPackageEntry_AndSnapshotSize()
+    {
+        // Arrange — a product packaged 6-to-a-pack; an item entered as 3 packs = 18 base units. R21: server
+        // computes the base quantity from the product's size and snapshots it; the client sends no size.
+        var partner = await CreatePartnerAsync($"Partner pack {Guid.NewGuid()}");
+        var productId = await CreateProductAsync(packageSize: 6);
+        // The client's base Quantity (999) is deliberately wrong to prove the server recomputes 3 × 6.
+        var request = new CreateTemplateRequest(
+            partner.Id,
+            $"Template {Guid.NewGuid():N}",
+            TemplateType.Sale,
+            [new CreateTemplateItem(ProductId: productId, Quantity: 999, UnitPrice: 1_000m, Discount: 0m, DiscountType: DiscountType.Fixed, PackageQuantity: 3)]);
+
+        // Act
+        var created = await _client.PostAsync<CreateTemplateResponse>(GetUrl(), request);
+        var fetched = await _client.GetAsync<TemplateDto>(GetUrl(created.Id));
+
+        // Assert — create response and a fresh read both carry the computed base quantity + the size snapshot.
+        var createdItem = Assert.Single(created.Items);
+        Assert.Equal(18m, createdItem.Quantity);
+        Assert.Equal(6, createdItem.PackageSize);
+
+        var fetchedItem = Assert.Single(fetched.Items);
+        Assert.Equal(18m, fetchedItem.Quantity);
+        Assert.Equal(6, fetchedItem.PackageSize);
+    }
+
+    [Fact]
+    public async Task Put_ShouldComputeBaseQuantityFromPackageEntry_WhenUpdatingAnExistingItem()
+    {
+        // Arrange — a base-unit item, then updated in place to a pack entry (exercises the update-existing branch).
+        var partner = await CreatePartnerAsync($"Partner pack upd {Guid.NewGuid()}");
+        var productId = await CreateProductAsync(packageSize: 6);
+        var created = await _client.PostAsync<CreateTemplateResponse>(GetUrl(), new CreateTemplateRequest(
+            partner.Id,
+            $"Template {Guid.NewGuid():N}",
+            TemplateType.Sale,
+            [new CreateTemplateItem(ProductId: productId, Quantity: 5, UnitPrice: 1_000m, Discount: 0m)]));
+        var itemId = Assert.Single(created.Items).Id;
+
+        var updateRequest = new UpdateTemplateRequest(
+            created.Id,
+            partner.Id,
+            created.Name,
+            TemplateType.Sale,
+            [new UpdateTemplateItem(Id: itemId, ProductId: productId, Quantity: 999, UnitPrice: 1_000m, Discount: 0m, DiscountType: DiscountType.Fixed, PackageQuantity: 2)]);
+
+        // Act
+        await _client.PutAsync<UpdateTemplateResponse>(GetUrl(created.Id), updateRequest);
+        var fetched = await _client.GetAsync<TemplateDto>(GetUrl(created.Id));
+
+        // Assert — 2 packs × 6 = 12 base units, size snapshotted.
+        var item = Assert.Single(fetched.Items);
+        Assert.Equal(12m, item.Quantity);
+        Assert.Equal(6, item.PackageSize);
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/TemplateEndpoints/TemplateTestsBase.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/TemplateEndpoints/TemplateTestsBase.cs
@@ -63,7 +63,7 @@ public abstract class TemplateTestsBase(
         return partner;
     }
 
-    protected async Task<int> CreateProductAsync()
+    protected async Task<int> CreateProductAsync(int packageSize = 0)
     {
         var category = new Category { Name = $"Category {Guid.NewGuid():N}" };
         _context.Categories.Add(category);
@@ -81,6 +81,7 @@ public abstract class TemplateTestsBase(
             Type = ProductType.All,
             CategoryId = category.Id,
             Category = null!,
+            Packaging = new ProductPackaging { Size = packageSize },
         };
         _context.Products.Add(product);
         await _context.SaveChangesAsync();

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Package.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/CreateTransactionTests.Package.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Transaction;
+using Ombor.Contracts.Responses.Transaction;
+using Ombor.Tests.Common.Factories;
+
+namespace Ombor.Tests.Integration.Endpoints.Transactions;
+
+public partial class CreateTransactionTests
+{
+    // R21: a package-entry line is resolved to base units server-side from the product's package size (which
+    // the client never supplies), and the size is snapshotted on the line for audit.
+
+    [Fact]
+    public async Task CreateAsync_ShouldComputeBaseQuantityFromPackageEntry_AndSnapshotProductSize()
+    {
+        // Arrange — a product packaged 12-to-a-box; a Sale entered as 2 boxes = 24 base units, from 100 on hand.
+        var partnerId = await CreatePartnerAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync(packageSize: 12);
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        // The client's base Quantity is deliberately wrong (999) to prove the server ignores it and recomputes
+        // the base from the pack count × the product's authoritative size.
+        var request = BuildSale(partnerId, productId, warehouseId, quantity: 999m, packageQuantity: 2);
+
+        // Act
+        var created = await PostTransactionAsync(request);
+
+        // Assert — server computed base Quantity = 2 × 12 and snapshotted the size; the client's 999 was ignored.
+        var createdLine = Assert.Single(created.Lines);
+        Assert.Equal(24m, createdLine.Quantity);
+        Assert.Equal(12, createdLine.PackageSize);
+
+        // The detail projection serves the same.
+        var detail = await _client.GetAsync<TransactionDetailDto>(GetUrl(created.Id));
+        var detailLine = Assert.Single(detail.Lines);
+        Assert.Equal(24m, detailLine.Quantity);
+        Assert.Equal(12, detailLine.PackageSize);
+
+        // Stock moved by the computed base quantity (24), not the pack count.
+        var item = await _context.WarehouseItems.AsNoTracking()
+            .FirstAsync(i => i.WarehouseId == warehouseId && i.ProductId == productId);
+        Assert.Equal(76m, item.Quantity);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectPackageEntry_WhenProductHasNoPackageSize()
+    {
+        // Arrange — a product with no configured package size (0) cannot be entered in packages.
+        var partnerId = await CreatePartnerAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        var request = BuildSale(partnerId, productId, warehouseId, quantity: 24m, packageQuantity: 2);
+
+        // Act + Assert — a clean 400: a package entry against an unpackaged product is rejected.
+        await PostTransactionExpectingBadRequestAsync(request);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldLeavePackageSizeNull_WhenEnteredInBaseUnits()
+    {
+        // Arrange — a base-unit Sale (no pack count) against a packaged product.
+        var partnerId = await CreatePartnerAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync(packageSize: 12);
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        var request = TransactionRequestFactory.Sale(partnerId, productId, warehouseId, due: 5_000m, walletId: null, paidAmount: 0m);
+
+        // Act
+        var created = await PostTransactionAsync(request);
+
+        // Assert — no pack entry means no snapshot.
+        Assert.Null(Assert.Single(created.Lines).PackageSize);
+    }
+
+    private static CreateTransactionRequest BuildSale(int partnerId, int productId, int warehouseId, decimal quantity, int? packageQuantity)
+        => new(
+            PartnerId: partnerId,
+            Type: TransactionType.Sale,
+            Notes: null,
+            Lines: [new CreateTransactionLine(productId, UnitPrice: 1_000m, Discount: 0m, DiscountType.Percentage, quantity, packageQuantity)],
+            WalletId: null,
+            PaidAmount: 0m,
+            Settlements: null,
+            Overpayment: OverpaymentHandling.Change,
+            Attachments: null!,
+            WarehouseId: warehouseId);
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/TransactionTestsBase.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/TransactionTestsBase.cs
@@ -54,7 +54,7 @@ public abstract class TransactionsTestsBase(
         return warehouse.Id;
     }
 
-    protected async Task<int> CreateProductAsync()
+    protected async Task<int> CreateProductAsync(int packageSize = 0)
     {
         var category = new Category { Name = $"Category {Guid.NewGuid():N}" };
         _context.Categories.Add(category);
@@ -72,6 +72,7 @@ public abstract class TransactionsTestsBase(
             Type = ProductType.All,
             CategoryId = category.Id,
             Category = null!,
+            Packaging = new ProductPackaging { Size = packageSize },
         };
         _context.Products.Add(product);
         await _context.SaveChangesAsync();

--- a/tests/Ombor.Tests.Unit/Mappings/TemplateMappingsTests.cs
+++ b/tests/Ombor.Tests.Unit/Mappings/TemplateMappingsTests.cs
@@ -211,7 +211,7 @@ public sealed class TemplateMappingsTests
             ]);
 
         // Act
-        var entity = request.ToEntity();
+        var entity = request.ToEntity(new Dictionary<int, int>());
 
         // Assert – template
         Assert.Equal("Quarterly", entity.Name);
@@ -272,7 +272,7 @@ public sealed class TemplateMappingsTests
             ]);
 
         // Act
-        template.ApplyUpdate(updateRequest);
+        template.ApplyUpdate(updateRequest, new Dictionary<int, int>());
 
         // Assert
         Assert.Equal(updateRequest.PartnerId, template.PartnerId);


### PR DESCRIPTION
**F21** — persists package entry on transaction lines and template items for audit (rule 21), while stock still moves in base units. Off `redesign/issue-fixes`.

**Design (server-authoritative, per owner review):**
- The request carries only the entered pack count (`int? PackageQuantity`). The **server** reads `Product.Packaging.Size`, computes base `Quantity = count × size`, and snapshots one nullable `int? PackageSize` on the line (null = base-unit entry; it doubles as the flag). The client never supplies the size; a client-sent base `Quantity` is recomputed, so the stored record can't drift.
- Base `Quantity` stays the sole source of truth for stock/WAC. The pack count is **not** stored — it's recoverable as `Quantity / PackageSize`.
- A package entry against a product with no configured size returns 400.
- Applies to transaction lines and template items (create + update paths). Migration adds two nullable `PackageSize` columns.

**FE contract:** request sends `packageQuantity`; response serves `packageSize` (FE derives the count).

**Tests:** integration round-trips incl. a proof the server recomputes a deliberately-wrong client base; unit mapping fixes. Full integration suite green (261/264; the 3 `PasswordResetTests` OTP failures are the pre-existing baseline).
