### PR TITLE
Serve payment attachments; switch payment-create to multipart (F18) [BREAKING]

### DIFF
--- a/src/Ombor.API/Controllers/PaymentsController.cs
+++ b/src/Ombor.API/Controllers/PaymentsController.cs
@@ -69,7 +69,7 @@ public sealed class PaymentsController(IPaymentService paymentService) : Control
     [ProducesResponseType(typeof(PaymentRecordDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<PaymentRecordDto>> PostAsync([FromBody] CreatePaymentRecordRequest request)
+    public async Task<ActionResult<PaymentRecordDto>> PostAsync([FromForm] CreatePaymentRecordRequest request)
     {
         var response = await paymentService.CreateRecordAsync(request);
 

--- a/src/Ombor.Application/Services/PaymentService.cs
+++ b/src/Ombor.Application/Services/PaymentService.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Ombor.Application.Extensions;
 using Ombor.Application.Interfaces;
+using Ombor.Application.Interfaces.File;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Requests.Payroll;
 using Ombor.Contracts.Responses.Payment;
@@ -14,8 +15,12 @@ namespace Ombor.Application.Services;
 internal sealed class PaymentService(
     IApplicationDbContext context,
     IRequestValidator validator,
+    IFileService fileService,
     INumberSequenceAllocator allocator) : IPaymentService
 {
+    // Uploaded payment files land here (originals + thumbnails under their standard sections).
+    private const string AttachmentsSubfolder = "payments";
+
     public async Task<PaymentRecordDto> CreateRecordAsync(CreatePaymentRecordRequest request)
     {
         await validator.ValidateAndThrowAsync(request);
@@ -150,11 +155,39 @@ internal sealed class PaymentService(
 
         payment.Number = await allocator.AllocateAsync(NumberSeriesType.Payment);
         context.Payments.Add(payment);
+        await AddAttachmentsAsync(request, payment);
         await context.SaveChangesAsync();
 
         await databaseTransaction.CommitAsync();
 
         return await GetRecordByIdAsync(payment.Id);
+    }
+
+    /// <summary>
+    /// Uploads the request's files and links them to the payment, mirroring the transaction attachment flow:
+    /// the original name, MIME type, and size are kept so the client can render each without re-reading the file.
+    /// </summary>
+    private async Task AddAttachmentsAsync(CreatePaymentRecordRequest request, Payment payment)
+    {
+        if (request.Attachments is not { Length: > 0 })
+        {
+            return;
+        }
+
+        foreach (var file in request.Attachments)
+        {
+            var uploaded = await fileService.UploadAsync(file, AttachmentsSubfolder);
+
+            payment.Attachments.Add(new PaymentAttachment
+            {
+                Payment = payment,
+                FileId = uploaded.FileName,
+                FileName = uploaded.OriginalFileName,
+                ContentType = string.IsNullOrWhiteSpace(file.ContentType) ? "application/octet-stream" : file.ContentType,
+                SizeBytes = file.Length,
+                Url = uploaded.Url,
+            });
+        }
     }
 
     public Task<PaymentRecordDto[]> GetRecordsAsync(GetPaymentsRequest request)
@@ -315,7 +348,13 @@ internal sealed class PaymentService(
                 a.Type.ToString(),
                 a.TransactionId,
                 a.Transaction != null ? a.Transaction.Type.ToString() : null,
-                a.Amount)).ToArray());
+                a.Amount)).ToArray(),
+            p.Attachments.Select(a => new PaymentAttachmentDto(
+                a.Id,
+                a.FileName,
+                a.ContentType,
+                a.SizeBytes,
+                a.Url)).ToArray());
 
     public async Task<PaymentRecordDto> CreateAsync(CreatePayrollRequest request)
     {

--- a/src/Ombor.Contracts/Requests/Payment/CreatePaymentRecordRequest.cs
+++ b/src/Ombor.Contracts/Requests/Payment/CreatePaymentRecordRequest.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Ombor.Contracts.Enums;
 
 namespace Ombor.Contracts.Requests.Payment;
@@ -16,6 +17,7 @@ namespace Ombor.Contracts.Requests.Payment;
 /// <param name="Description">Required for General payments.</param>
 /// <param name="Period">Payroll period, e.g. «2026-06».</param>
 /// <param name="Settlements">Per-transaction amounts this payment settles.</param>
+/// <param name="Attachments">Optional file attachments (receipts, transfer confirmations). Sent as multipart/form-data.</param>
 public sealed record CreatePaymentRecordRequest(
     PaymentType Type,
     PaymentDirection Direction,
@@ -25,7 +27,8 @@ public sealed record CreatePaymentRecordRequest(
     decimal Amount,
     string? Description,
     string? Period,
-    SettlementInput[] Settlements);
+    SettlementInput[] Settlements,
+    IFormFile[]? Attachments = null);
 
 /// <summary>A single transaction-settlement instruction within a payment.</summary>
 /// <param name="TransactionId">The transaction being settled.</param>

--- a/src/Ombor.Contracts/Responses/Payment/PaymentRecordDto.cs
+++ b/src/Ombor.Contracts/Responses/Payment/PaymentRecordDto.cs
@@ -26,7 +26,24 @@ public sealed record PaymentRecordDto(
     decimal? Salary,
     string? CreatedBy,
     PaymentSourceDto[] Sources,
-    PaymentAllocationEntryDto[] Allocations);
+    PaymentAllocationEntryDto[] Allocations,
+    PaymentAttachmentDto[] Attachments);
+
+/// <summary>
+/// A file uploaded with a payment. Raw values only — the client derives the icon from
+/// <see cref="ContentType"/> and formats <see cref="SizeBytes"/> for display. Mirrors the transaction attachment shape.
+/// </summary>
+/// <param name="Id">The attachment id.</param>
+/// <param name="Name">The original file name as uploaded.</param>
+/// <param name="ContentType">The MIME type (e.g. application/pdf, image/jpeg).</param>
+/// <param name="SizeBytes">The file size in bytes.</param>
+/// <param name="Url">The public URL to fetch the file.</param>
+public sealed record PaymentAttachmentDto(
+    int Id,
+    string Name,
+    string ContentType,
+    long SizeBytes,
+    string Url);
 
 /// <summary>The source side of a payment (rule 9): a wallet draw or a draw against the partner's advance.</summary>
 public sealed record PaymentSourceDto(

--- a/src/Ombor.Domain/Entities/PaymentAttachment.cs
+++ b/src/Ombor.Domain/Entities/PaymentAttachment.cs
@@ -1,13 +1,30 @@
-﻿using Ombor.Domain.Common;
+using Ombor.Domain.Common;
 
 namespace Ombor.Domain.Entities;
 
+/// <summary>
+/// A file uploaded with a payment (receipt, transfer confirmation, etc.). Stored with enough metadata
+/// for the client to render it without re-reading the file: original name, MIME type, size, and URL.
+/// Mirrors <see cref="TransactionAttachment"/>.
+/// </summary>
 public class PaymentAttachment : EntityBase, IOrganizationScoped
 {
     public int OrganizationId { get; set; }
 
+    /// <summary>The storage key (generated file name) used to locate/delete the stored file.</summary>
     public required string FileId { get; set; }
+
+    /// <summary>The original file name as uploaded; shown to the user.</summary>
     public required string FileName { get; set; }
+
+    /// <summary>The MIME type (e.g. application/pdf, image/jpeg); the client derives its icon from it.</summary>
+    public required string ContentType { get; set; }
+
+    /// <summary>The file size in bytes; the client formats it for display.</summary>
+    public long SizeBytes { get; set; }
+
+    /// <summary>The public URL to fetch the file.</summary>
+    public required string Url { get; set; }
 
     public int PaymentId { get; set; }
     public virtual required Payment Payment { get; set; }

--- a/src/Ombor.Infrastructure/Persistence/Configurations/PaymentAttachmentConfiguration.cs
+++ b/src/Ombor.Infrastructure/Persistence/Configurations/PaymentAttachmentConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Ombor.Domain.Entities;
 
@@ -26,6 +26,17 @@ internal sealed class PaymentAttachmentConfiguration : IEntityTypeConfiguration<
 
         builder
             .Property(pa => pa.FileName)
-            .HasMaxLength(ConfigurationConstants.MaxStringLength);
+            .HasMaxLength(ConfigurationConstants.MaxStringLength)
+            .IsRequired();
+
+        builder
+            .Property(pa => pa.ContentType)
+            .HasMaxLength(ConfigurationConstants.DefaultStringLength)
+            .IsRequired();
+
+        builder
+            .Property(pa => pa.Url)
+            .HasMaxLength(ConfigurationConstants.MaxStringLength)
+            .IsRequired();
     }
 }

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719114018_Add_Payment_Attachment_Metadata.Designer.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719114018_Add_Payment_Attachment_Metadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombor.Infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using Ombor.Infrastructure.Persistence;
 namespace Ombor.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719114018_Add_Payment_Attachment_Metadata")]
+    partial class Add_Payment_Attachment_Metadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719114018_Add_Payment_Attachment_Metadata.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719114018_Add_Payment_Attachment_Metadata.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombor.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Payment_Attachment_Metadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ContentType",
+                table: "PaymentAttachment",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<long>(
+                name: "SizeBytes",
+                table: "PaymentAttachment",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Url",
+                table: "PaymentAttachment",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContentType",
+                table: "PaymentAttachment");
+
+            migrationBuilder.DropColumn(
+                name: "SizeBytes",
+                table: "PaymentAttachment");
+
+            migrationBuilder.DropColumn(
+                name: "Url",
+                table: "PaymentAttachment");
+        }
+    }
+}

--- a/tests/Ombor.Tests.Common/Extensions/RequestExtensions.cs
+++ b/tests/Ombor.Tests.Common/Extensions/RequestExtensions.cs
@@ -4,6 +4,7 @@ using Ombor.Contracts.Requests.Category;
 using Ombor.Contracts.Requests.Employee;
 using Ombor.Contracts.Requests.Warehouse;
 using Ombor.Contracts.Requests.Partner;
+using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Requests.Product;
 using Ombor.Contracts.Requests.Template;
 using Ombor.Contracts.Requests.Transaction;
@@ -138,6 +139,51 @@ public static class RequestExtensions
             foreach (var imageIdToDelete in request.ImagesToDelete)
             {
                 content.Add(new StringContent(imageIdToDelete.ToString()), nameof(request.ImagesToDelete));
+            }
+        }
+
+        return content;
+    }
+
+    public static MultipartFormDataContent ToMultipartFormData(this CreatePaymentRecordRequest request)
+    {
+        var content = new MultipartFormDataContent
+        {
+            { new StringContent(((int)request.Type).ToString()),      nameof(request.Type) },
+            { new StringContent(((int)request.Direction).ToString()), nameof(request.Direction) },
+            { new StringContent(request.WalletId.ToString()),         nameof(request.WalletId) },
+            { new StringContent(request.Amount.ToString(cultureInfo)), nameof(request.Amount) },
+        };
+
+        if (request.PartnerId.HasValue)
+            content.Add(new StringContent(request.PartnerId.Value.ToString()), nameof(request.PartnerId));
+
+        if (request.EmployeeId.HasValue)
+            content.Add(new StringContent(request.EmployeeId.Value.ToString()), nameof(request.EmployeeId));
+
+        if (request.Description is not null)
+            content.Add(new StringContent(request.Description), nameof(request.Description));
+
+        if (request.Period is not null)
+            content.Add(new StringContent(request.Period), nameof(request.Period));
+
+        if (request.Settlements is not null)
+        {
+            for (var i = 0; i < request.Settlements.Length; i++)
+            {
+                var s = request.Settlements[i];
+                content.Add(new StringContent(s.TransactionId.ToString()), $"Settlements[{i}].TransactionId");
+                content.Add(new StringContent(s.Amount.ToString(cultureInfo)), $"Settlements[{i}].Amount");
+            }
+        }
+
+        if (request.Attachments is not null)
+        {
+            foreach (var f in request.Attachments)
+            {
+                var fc = new StreamContent(f.OpenReadStream());
+                fc.Headers.ContentType = MediaTypeHeaderValue.Parse(f.ContentType ?? "application/octet-stream");
+                content.Add(fc, nameof(request.Attachments), f.FileName);
             }
         }
 

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePaymentAttachmentTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePaymentAttachmentTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Http;
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Payment;
+using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Common.Extensions;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.PaymentEndpoints;
+
+public sealed class CreatePaymentAttachmentTests(TestingWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    : PaymentTestsBase(factory, outputHelper)
+{
+    [Fact]
+    public async Task PostAsync_ShouldPersistAttachment_ExposedOnCreateAndGet()
+    {
+        // Arrange — a General expense payment carrying one uploaded file (F18).
+        var walletId = await CreateWalletAsync(10_000m);
+
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.General, PaymentDirection.Expense, null, null, walletId,
+            Amount: 4_000m, Description: "office supplies", Period: null, Settlements: [],
+            Attachments: [BuildFile("receipt.pdf", "application/pdf", content)]);
+
+        // Act
+        var created = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
+        var fetched = await _client.GetAsync<PaymentRecordDto>(GetUrl(created.Id));
+
+        // Assert — the file is stored with raw metadata and a fetchable URL, on the create response and a fresh read.
+        foreach (var payment in new[] { created, fetched })
+        {
+            var attachment = Assert.Single(payment.Attachments);
+            Assert.Equal("receipt.pdf", attachment.Name);
+            Assert.Equal("application/pdf", attachment.ContentType);
+            Assert.Equal(content.Length, attachment.SizeBytes);
+            Assert.False(string.IsNullOrWhiteSpace(attachment.Url));
+        }
+    }
+
+    [Fact]
+    public async Task PostAsync_ShouldReturnEmptyAttachments_WhenNoneUploaded()
+    {
+        // Arrange — a payment with no files.
+        var walletId = await CreateWalletAsync(10_000m);
+        var request = new CreatePaymentRecordRequest(
+            PaymentType.General, PaymentDirection.Expense, null, null, walletId,
+            Amount: 1_000m, Description: "misc", Period: null, Settlements: []);
+
+        // Act
+        var created = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
+
+        // Assert
+        Assert.Empty(created.Attachments);
+    }
+
+    private static FormFile BuildFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+
+        return new FormFile(stream, 0, content.Length, "Attachments", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType,
+        };
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePaymentRecordTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/CreatePaymentRecordTests.cs
@@ -5,6 +5,7 @@ using Ombor.Contracts.Enums;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Responses.Payment;
 using Ombor.Domain.Entities;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 
@@ -27,7 +28,7 @@ public sealed class CreatePaymentRecordTests(TestingWebApplicationFactory factor
             Settlements: [new SettlementInput(saleId, 10_000m)]);
 
         // Act
-        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
 
         // Assert — one wallet source = one settling allocation (rule 8).
         var source = Assert.Single(payment.Sources);
@@ -59,7 +60,7 @@ public sealed class CreatePaymentRecordTests(TestingWebApplicationFactory factor
             Settlements: [new SettlementInput(saleId, 6_000m)]);
 
         // Act
-        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
 
         // Assert — settlement + advance, and they sum to the wallet source (rule 8).
         Assert.Contains(payment.Allocations, a => a.AllocationType == "TransactionSettlement" && a.Amount == 6_000m && a.TransactionType == "Sale");
@@ -82,7 +83,7 @@ public sealed class CreatePaymentRecordTests(TestingWebApplicationFactory factor
             Settlements: [new SettlementInput(saleId, 6_000m)]);
 
         // Act & Assert
-        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -97,7 +98,7 @@ public sealed class CreatePaymentRecordTests(TestingWebApplicationFactory factor
             Amount: 8_000m, Description: null, Period: null,
             Settlements: [new SettlementInput(saleId, 8_000m)]);
 
-        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -109,6 +110,6 @@ public sealed class CreatePaymentRecordTests(TestingWebApplicationFactory factor
             PaymentType.Deposit, PaymentDirection.Income, partnerId, null, NonExistentEntityId,
             Amount: 1_000m, Description: null, Period: null, Settlements: []);
 
-        await _client.PostAsync<ProblemDetails>(GetUrl(), request, HttpStatusCode.NotFound);
+        await _client.PostAsync<ProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.NotFound);
     }
 }

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PartnerBalanceTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PartnerBalanceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Ombor.Contracts.Enums;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 
@@ -28,7 +29,7 @@ public sealed class PartnerBalanceTests(TestingWebApplicationFactory factory, IT
         // Act — settle the sale in full.
         await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
-            10_000m, null, null, [new SettlementInput(saleId, 10_000m)]));
+            10_000m, null, null, [new SettlementInput(saleId, 10_000m)]).ToMultipartFormData());
 
         // Assert — debt cleared.
         Assert.Equal(0m, await BalanceTotalAsync(partnerId));
@@ -36,7 +37,7 @@ public sealed class PartnerBalanceTests(TestingWebApplicationFactory factory, IT
         // Act — partner deposits 5,000 with no debt outstanding (becomes an advance).
         await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.Deposit, PaymentDirection.Income, partnerId, null, walletId,
-            5_000m, null, null, []));
+            5_000m, null, null, []).ToMultipartFormData());
 
         // Assert — we now owe the partner their 5,000 advance (negative balance).
         Assert.Equal(-5_000m, await BalanceTotalAsync(partnerId));

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PaymentLedgerIntegrityTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/PaymentLedgerIntegrityTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Ombor.Contracts.Enums;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 
@@ -31,7 +32,7 @@ public sealed class PaymentLedgerIntegrityTests(TestingWebApplicationFactory fac
             Settlements: [new SettlementInput(partnerBSaleId, 10_000m)]);
 
         // Act & Assert — a clean 400, and partner B's sale is untouched.
-        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.BadRequest);
 
         var sale = await _context.Transactions.AsNoTracking().FirstAsync(t => t.Id == partnerBSaleId);
         Assert.Equal(0m, sale.TotalPaid);
@@ -51,7 +52,7 @@ public sealed class PaymentLedgerIntegrityTests(TestingWebApplicationFactory fac
             Settlements: [new SettlementInput(saleId, 6_000m), new SettlementInput(saleId, 6_000m)]);
 
         // Act & Assert — a clean 400, never a 500, and the sale is untouched.
-        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.BadRequest);
 
         var sale = await _context.Transactions.AsNoTracking().FirstAsync(t => t.Id == saleId);
         Assert.Equal(0m, sale.TotalPaid);
@@ -71,7 +72,7 @@ public sealed class PaymentLedgerIntegrityTests(TestingWebApplicationFactory fac
             Settlements: [new SettlementInput(saleId, 4_000m), new SettlementInput(saleId, 6_000m)]);
 
         // Act
-        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
 
         // Assert — one merged allocation of 10,000 and the sale is paid once, not twice.
         var allocation = Assert.Single(payment.Allocations);
@@ -94,12 +95,12 @@ public sealed class PaymentLedgerIntegrityTests(TestingWebApplicationFactory fac
         var first = await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
             Amount: 5_000m, Description: null, Period: null,
-            Settlements: [new SettlementInput(firstSaleId, 5_000m)]));
+            Settlements: [new SettlementInput(firstSaleId, 5_000m)]).ToMultipartFormData());
 
         var second = await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
             Amount: 5_000m, Description: null, Period: null,
-            Settlements: [new SettlementInput(secondSaleId, 5_000m)]));
+            Settlements: [new SettlementInput(secondSaleId, 5_000m)]).ToMultipartFormData());
 
         Assert.True(int.TryParse(first.Number, out _)); // bare sequential number, no "P-" prefix
         Assert.True(int.TryParse(second.Number, out _));

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/ReadPaymentTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/ReadPaymentTests.cs
@@ -4,6 +4,7 @@ using Ombor.Contracts.Enums;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Responses.Payment;
 using Ombor.Domain.Entities;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
@@ -22,7 +23,7 @@ public sealed class ReadPaymentTests(TestingWebApplicationFactory factory, ITest
         var saleId = await CreateOpenSaleAsync(partnerId, total: 3_000m);
         var created = await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.Transaction, PaymentDirection.Income, partnerId, null, walletId,
-            3_000m, null, null, [new SettlementInput(saleId, 3_000m)]));
+            3_000m, null, null, [new SettlementInput(saleId, 3_000m)]).ToMultipartFormData());
 
         // Act
         var fetched = await _client.GetAsync<PaymentRecordDto>(GetUrl(created.Id));

--- a/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/WalletOverdraftTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PaymentEndpoints/WalletOverdraftTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Ombor.Contracts.Enums;
 using Ombor.Contracts.Requests.Payment;
 using Ombor.Contracts.Responses.Payment;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 
@@ -24,7 +25,7 @@ public sealed class WalletOverdraftTests(TestingWebApplicationFactory factory, I
             PaymentType.General, PaymentDirection.Expense, null, null, walletId,
             Amount: 5_000m, Description: "office supplies", Period: null, Settlements: []);
 
-        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request, HttpStatusCode.BadRequest);
+        await _client.PostAsync<ValidationProblemDetails>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.BadRequest);
     }
 
     [Fact]
@@ -36,7 +37,7 @@ public sealed class WalletOverdraftTests(TestingWebApplicationFactory factory, I
             PaymentType.General, PaymentDirection.Expense, null, null, walletId,
             Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []);
 
-        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request);
+        var payment = await _client.PostAsync<PaymentRecordDto>(GetUrl(), request.ToMultipartFormData());
         Assert.Equal("Expense", payment.Direction);
     }
 
@@ -47,7 +48,7 @@ public sealed class WalletOverdraftTests(TestingWebApplicationFactory factory, I
         var walletId = await CreateWalletAsync(10_000m);
         await _client.PostAsync<PaymentRecordDto>(GetUrl(), new CreatePaymentRecordRequest(
             PaymentType.General, PaymentDirection.Expense, null, null, walletId,
-            Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []));
+            Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []).ToMultipartFormData());
 
         var form = await _client.GetAsync<PaymentFormDataDto>($"{GetUrl()}/form-data");
 

--- a/tests/Ombor.Tests.Integration/Endpoints/WalletEndpoints/WalletPaymentBalanceTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/WalletEndpoints/WalletPaymentBalanceTests.cs
@@ -4,6 +4,7 @@ using Ombor.Contracts.Requests.Wallet;
 using Ombor.Contracts.Responses.Payment;
 using Ombor.Contracts.Responses.Wallet;
 using Ombor.Domain.Entities;
+using Ombor.Tests.Common.Extensions;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 using PartnerType = Ombor.Domain.Enums.PartnerType;
@@ -24,7 +25,7 @@ public sealed class WalletPaymentBalanceTests(TestingWebApplicationFactory facto
         var request = new CreatePaymentRecordRequest(
             PaymentType.Deposit, PaymentDirection.Income, partnerId, null, walletId,
             Amount: 5_000m, Description: null, Period: null, Settlements: []);
-        await _client.PostAsync<PaymentRecordDto>("payments", request);
+        await _client.PostAsync<PaymentRecordDto>("payments", request.ToMultipartFormData());
 
         // Assert — balance includes the wallet-sourced component; advances aren't attributed yet.
         var wallet = await _client.GetAsync<WalletDto>(GetUrl(walletId));
@@ -52,7 +53,7 @@ public sealed class WalletPaymentBalanceTests(TestingWebApplicationFactory facto
         var request = new CreatePaymentRecordRequest(
             PaymentType.General, PaymentDirection.Expense, null, null, walletId,
             Amount: 4_000m, Description: "office supplies", Period: null, Settlements: []);
-        await _client.PostAsync<PaymentRecordDto>("payments", request);
+        await _client.PostAsync<PaymentRecordDto>("payments", request.ToMultipartFormData());
 
         // Assert
         var wallet = await _client.GetAsync<WalletDto>(GetUrl(walletId));
@@ -78,7 +79,7 @@ public sealed class WalletPaymentBalanceTests(TestingWebApplicationFactory facto
 
         await _client.PostAsync<PaymentRecordDto>("payments", new CreatePaymentRecordRequest(
             PaymentType.Deposit, PaymentDirection.Income, partnerId, null, walletId,
-            Amount: 500m, Description: null, Period: null, Settlements: []));
+            Amount: 500m, Description: null, Period: null, Settlements: []).ToMultipartFormData());
 
         await _client.PostAsync<WalletTransferDto>(
             $"{GetUrl()}/transfers",


### PR DESCRIPTION
**F18** — serves payment attachments end-to-end. Off `redesign/issue-fixes`.

## ⚠ Breaking contract change — coordinate with the frontend
Payment-create moves from a **JSON body to `multipart/form-data`** so files can be uploaded. The FE payment-create call must switch to multipart, and `frontend-gaps.md` F18 should be updated by an FE session.

- Grows `PaymentAttachment` to `{ContentType, SizeBytes, Url}`, mirroring `TransactionAttachment`; EF migration adds the three columns (safe defaults).
- `PaymentsController.PostAsync` is now `[FromForm]`; `CreatePaymentRecordRequest` gains `IFormFile[]? Attachments`.
- `PaymentService` injects `IFileService` and uploads via `AddAttachmentsAsync` (subfolder `"payments"`), mirroring the transaction flow; `PaymentRecordDto` gains an `Attachments` array, projected in `ToRecordExpression`.
- Notes already round-trip (`Description` ↔ `Notes`), so this is **attachments only**.

**Tests:** migrated every existing payment-create test to multipart; added an attachment round-trip test. Full integration suite green (258/261; the 3 `PasswordResetTests` OTP failures are the pre-existing baseline).
