### PR TITLE
Add Partner Telegram field (F12)

### DIFF
--- a/src/Ombor.Application/Mappings/SupplierMappings.cs
+++ b/src/Ombor.Application/Mappings/SupplierMappings.cs
@@ -14,6 +14,7 @@ internal static class PartnerMappings
             Address = request.Address,
             Email = request.Email,
             CompanyName = request.CompanyName,
+            Telegram = request.Telegram,
             Type = Enum.Parse<PartnerType>(request.Type.ToString()),
             OpeningBalance = request.OpeningBalance,
             PhoneNumbers = request.PhoneNumbers
@@ -29,7 +30,8 @@ internal static class PartnerMappings
             OpeningBalance: partner.OpeningBalance,
             OpeningDate: partner.OpeningDate,
             IsArchived: partner.IsArchived,
-            PhoneNumbers: partner.PhoneNumbers);
+            PhoneNumbers: partner.PhoneNumbers,
+            Telegram: partner.Telegram);
 
     public static UpdatePartnerResponse ToUpdateResponse(this Partner partner) =>
         new(Id: partner.Id,
@@ -41,7 +43,8 @@ internal static class PartnerMappings
             OpeningBalance: partner.OpeningBalance,
             OpeningDate: partner.OpeningDate,
             IsArchived: partner.IsArchived,
-            PhoneNumbers: partner.PhoneNumbers);
+            PhoneNumbers: partner.PhoneNumbers,
+            Telegram: partner.Telegram);
 
     // Opening balance/date are immutable (set once at creation) — the update never touches them.
     public static void ApplyUpdate(this Partner partner, UpdatePartnerRequest request)
@@ -50,6 +53,7 @@ internal static class PartnerMappings
         partner.Address = request.Address;
         partner.Email = request.Email;
         partner.CompanyName = request.CompanyName;
+        partner.Telegram = request.Telegram;
         partner.PhoneNumbers = request.PhoneNumbers;
         partner.Type = Enum.Parse<PartnerType>(request.Type.ToString());
     }

--- a/src/Ombor.Application/Services/PartnerService.cs
+++ b/src/Ombor.Application/Services/PartnerService.cs
@@ -215,6 +215,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
                 x.partner.Address,
                 x.partner.Email,
                 x.partner.CompanyName,
+                x.partner.Telegram,
                 x.partner.PhoneNumbers,
                 x.partner.OpeningBalance,
                 x.partner.OpeningDate,
@@ -240,7 +241,8 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
             r.OpeningDate,
             r.IsArchived,
             r.ActivityCount == 0,
-            r.ActivityCount))];
+            r.ActivityCount,
+            r.Telegram))];
     }
 
     private async Task<Partner> GetOrThrowAsync(int id) =>

--- a/src/Ombor.Application/Validators/Partner/CreatePartnerRequestValidator.cs
+++ b/src/Ombor.Application/Validators/Partner/CreatePartnerRequestValidator.cs
@@ -28,6 +28,11 @@ public sealed class CreatePartnerRequestValidator : AbstractValidator<CreatePart
             .MaximumLength(ValidationConstants.DefaultStringLength)
             .WithMessage($"Company name must not exceed {ValidationConstants.DefaultStringLength} characters.");
 
+        // Length only — the client validates the handle format.
+        RuleFor(x => x.Telegram)
+            .MaximumLength(ValidationConstants.DefaultStringLength)
+            .WithMessage($"Telegram handle must not exceed {ValidationConstants.DefaultStringLength} characters.");
+
         RuleForEach(x => x.PhoneNumbers)
             .Must(ValidationHelpers.IsValidPhoneNumber)
             .WithMessage("One or more phone numbers are in invalid format.");

--- a/src/Ombor.Application/Validators/Partner/UpdatePartnerRequestValidator.cs
+++ b/src/Ombor.Application/Validators/Partner/UpdatePartnerRequestValidator.cs
@@ -31,6 +31,11 @@ public sealed class UpdatePartnerRequestValidator : AbstractValidator<UpdatePart
             .MaximumLength(ValidationConstants.DefaultStringLength)
             .WithMessage($"Company name must not exceed {ValidationConstants.DefaultStringLength} characters.");
 
+        // Length only — the client validates the handle format.
+        RuleFor(x => x.Telegram)
+            .MaximumLength(ValidationConstants.DefaultStringLength)
+            .WithMessage($"Telegram handle must not exceed {ValidationConstants.DefaultStringLength} characters.");
+
         RuleForEach(x => x.PhoneNumbers)
             .Must(ValidationHelpers.IsValidPhoneNumber)
             .WithMessage("The phone number is in the wrong format.");

--- a/src/Ombor.Contracts/Requests/Partner/CreatePartnerRequest.cs
+++ b/src/Ombor.Contracts/Requests/Partner/CreatePartnerRequest.cs
@@ -12,6 +12,7 @@ namespace Ombor.Contracts.Requests.Partner;
 /// <param name="OpeningBalance">The partner's starting balance, recorded once as an immutable event (signed: positive = the partner owes us).</param>
 /// <param name="Type">The type of the partner.</param>
 /// <param name="PhoneNumbers">The partner's phone numbers.</param>
+/// <param name="Telegram">An optional Telegram handle (contact only; handle format is validated on the client).</param>
 public sealed record CreatePartnerRequest(
     string Name,
     string? Address,
@@ -19,4 +20,5 @@ public sealed record CreatePartnerRequest(
     string? CompanyName,
     decimal OpeningBalance,
     PartnerType Type,
-    List<string> PhoneNumbers);
+    List<string> PhoneNumbers,
+    string? Telegram = null);

--- a/src/Ombor.Contracts/Requests/Partner/UpdatePartnerRequest.cs
+++ b/src/Ombor.Contracts/Requests/Partner/UpdatePartnerRequest.cs
@@ -12,6 +12,7 @@ namespace Ombor.Contracts.Requests.Partner;
 /// <param name="CompanyName">An optional new company name.</param>
 /// <param name="Type">The type of the partner.</param>
 /// <param name="PhoneNumbers">New phone numbers of partner.</param>
+/// <param name="Telegram">An optional Telegram handle (contact only; handle format is validated on the client).</param>
 public sealed record UpdatePartnerRequest(
     int Id,
     string Name,
@@ -19,4 +20,5 @@ public sealed record UpdatePartnerRequest(
     string? Email,
     string? CompanyName,
     PartnerType Type,
-    List<string> PhoneNumbers);
+    List<string> PhoneNumbers,
+    string? Telegram = null);

--- a/src/Ombor.Contracts/Responses/Partner/CreatePartnerResponse.cs
+++ b/src/Ombor.Contracts/Responses/Partner/CreatePartnerResponse.cs
@@ -13,6 +13,7 @@ namespace Ombor.Contracts.Responses.Partner;
 /// <param name="OpeningDate">The date the opening balance was recorded.</param>
 /// <param name="IsArchived">Whether the partner is archived.</param>
 /// <param name="PhoneNumbers">Phone numbers of partner.</param>
+/// <param name="Telegram">The partner's Telegram handle, if any.</param>
 public sealed record CreatePartnerResponse(
     int Id,
     string Name,
@@ -23,4 +24,5 @@ public sealed record CreatePartnerResponse(
     decimal OpeningBalance,
     DateOnly OpeningDate,
     bool IsArchived,
-    List<string> PhoneNumbers);
+    List<string> PhoneNumbers,
+    string? Telegram = null);

--- a/src/Ombor.Contracts/Responses/Partner/PartnerDto.cs
+++ b/src/Ombor.Contracts/Responses/Partner/PartnerDto.cs
@@ -16,6 +16,7 @@ namespace Ombor.Contracts.Responses.Partner;
 /// <param name="IsArchived">Whether the partner is archived.</param>
 /// <param name="IsDeletable">True when no other record references the partner (otherwise DELETE returns 409).</param>
 /// <param name="ActivityCount">Number of records referencing the partner (transactions, payments, orders, templates).</param>
+/// <param name="Telegram">The partner's Telegram handle, if any.</param>
 public sealed record PartnerDto(
     int Id,
     string Name,
@@ -29,4 +30,5 @@ public sealed record PartnerDto(
     DateOnly OpeningDate,
     bool IsArchived,
     bool IsDeletable,
-    int ActivityCount);
+    int ActivityCount,
+    string? Telegram = null);

--- a/src/Ombor.Contracts/Responses/Partner/UpdatePartnerResponse.cs
+++ b/src/Ombor.Contracts/Responses/Partner/UpdatePartnerResponse.cs
@@ -13,6 +13,7 @@ namespace Ombor.Contracts.Responses.Partner;
 /// <param name="OpeningDate">The date the opening balance was recorded.</param>
 /// <param name="IsArchived">Whether the partner is archived.</param>
 /// <param name="PhoneNumbers">Updated phone numbers.</param>
+/// <param name="Telegram">The partner's Telegram handle, if any.</param>
 public sealed record UpdatePartnerResponse(
     int Id,
     string Name,
@@ -23,4 +24,5 @@ public sealed record UpdatePartnerResponse(
     decimal OpeningBalance,
     DateOnly OpeningDate,
     bool IsArchived,
-    List<string> PhoneNumbers);
+    List<string> PhoneNumbers,
+    string? Telegram = null);

--- a/src/Ombor.Domain/Entities/Partner.cs
+++ b/src/Ombor.Domain/Entities/Partner.cs
@@ -25,6 +25,9 @@ public class Partner : EntityBase, IOrganizationScoped
     /// <summary>Gets or sets the name of the company associated with the partner.</summary>
     public string? CompanyName { get; set; }
 
+    /// <summary>Gets or sets the partner's Telegram handle (contact only; handle format is validated on the client).</summary>
+    public string? Telegram { get; set; }
+
     /// <summary>
     /// The partner's starting balance, recorded once at creation as an immutable event (signed:
     /// positive = the partner owes us). The net balance is computed from this plus the event log.

--- a/src/Ombor.Infrastructure/Persistence/Configurations/PartnerConfiguration.cs
+++ b/src/Ombor.Infrastructure/Persistence/Configurations/PartnerConfiguration.cs
@@ -48,6 +48,10 @@ internal sealed class PartnerConfiguration : IEntityTypeConfiguration<Partner>
             .HasMaxLength(ConfigurationConstants.DefaultStringLength);
 
         builder
+            .Property(p => p.Telegram)
+            .HasMaxLength(ConfigurationConstants.DefaultStringLength);
+
+        builder
             .Property(p => p.OpeningBalance)
             .HasCurrencyPrecision();
 

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719121532_Add_Partner_Telegram.Designer.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719121532_Add_Partner_Telegram.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ombor.Infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using Ombor.Infrastructure.Persistence;
 namespace Ombor.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719121532_Add_Partner_Telegram")]
+    partial class Add_Partner_Telegram
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ombor.Infrastructure/Persistence/Migrations/20260719121532_Add_Partner_Telegram.cs
+++ b/src/Ombor.Infrastructure/Persistence/Migrations/20260719121532_Add_Partner_Telegram.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ombor.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Partner_Telegram : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Telegram",
+                table: "Partner",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Telegram",
+                table: "Partner");
+        }
+    }
+}

--- a/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerTelegramTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerTelegramTests.cs
@@ -1,0 +1,49 @@
+using Ombor.Contracts.Responses.Partner;
+using Ombor.Tests.Common.Factories;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.PartnerEndpoints;
+
+public sealed class PartnerTelegramTests(TestingWebApplicationFactory factory, ITestOutputHelper output)
+    : PartnerTestsBase(factory, output)
+{
+    [Fact]
+    public async Task CreateThenUpdate_ShouldRoundTripTelegramHandle()
+    {
+        // Arrange — create a partner with a Telegram handle (F12).
+        var createRequest = PartnerRequestFactory.GenerateValidCreateRequest() with { Telegram = "@ombor_partner" };
+
+        // Act — create
+        var created = await _client.PostAsync<CreatePartnerResponse>(GetUrl(), createRequest);
+
+        // Assert — the create response and a fresh read both carry the handle.
+        Assert.Equal("@ombor_partner", created.Telegram);
+        var fetched = await _client.GetAsync<PartnerDto>(GetUrl(created.Id));
+        Assert.Equal("@ombor_partner", fetched.Telegram);
+
+        // Act — update the handle.
+        var updateRequest = PartnerRequestFactory.GenerateValidUpdateRequest(created.Id) with { Telegram = "@ombor_updated" };
+        var updated = await _client.PutAsync<UpdatePartnerResponse>(GetUrl(created.Id), updateRequest);
+
+        // Assert — the update response and a fresh read reflect the new handle.
+        Assert.Equal("@ombor_updated", updated.Telegram);
+        var refetched = await _client.GetAsync<PartnerDto>(GetUrl(created.Id));
+        Assert.Equal("@ombor_updated", refetched.Telegram);
+    }
+
+    [Fact]
+    public async Task Create_ShouldLeaveTelegramNull_WhenNotProvided()
+    {
+        // Arrange — the factory sends no Telegram.
+        var createRequest = PartnerRequestFactory.GenerateValidCreateRequest();
+
+        // Act
+        var created = await _client.PostAsync<CreatePartnerResponse>(GetUrl(), createRequest);
+        var fetched = await _client.GetAsync<PartnerDto>(GetUrl(created.Id));
+
+        // Assert
+        Assert.Null(created.Telegram);
+        Assert.Null(fetched.Telegram);
+    }
+}


### PR DESCRIPTION
**F12** — adds the Partner `Telegram` field. Off `redesign/issue-fixes`.

The FE partner form already collects, validates (handle format), and sends `telegram`, but the contract had **no such field** (`PartnerDto` / `CreatePartnerRequest` / `UpdatePartnerRequest`) — so the real backend silently dropped it (only the MSW mock accepted it).

- Adds a nullable `Telegram` to the `Partner` entity + config + EF migration.
- Accepts it on `CreatePartnerRequest` / `UpdatePartnerRequest` and persists it (`ToEntity` + `ApplyUpdate`); serves it on `PartnerDto` and the create/update responses.
- **Length-only validators** (≤250) — the client owns handle-format validation.
- Contract doc `partners-debts-dashboard.md` updated (in `Ombor.Docs`).

**Tests:** integration round-trip (create with a handle → GET; update the handle → GET) + a null-when-absent case. Full integration suite green (258/261; the 3 `PasswordResetTests` OTP failures are the pre-existing baseline).
