### PR TITLE
Fix the 3 PasswordReset tests to read the server-issued OTP

### DIFF
--- a/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthTestsBase.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/AuthTestsBase.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Ombor.Application.Interfaces;
 using Ombor.Domain.Entities;
+using Ombor.Domain.Enums;
 using Ombor.Tests.Integration.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Ombor.Tests.Integration.Endpoints.AuthEndpoints;
@@ -40,5 +42,20 @@ public abstract class AuthTestsBase(TestingWebApplicationFactory factory, ITestO
         await _context.SaveChangesAsync();
 
         return (user.Id, phone);
+    }
+
+    /// <summary>
+    /// Reads the OTP the server actually issued (via the shared in-memory store), instead of assuming a fixed
+    /// stub — the provider mints a random code (<c>OtpCodeProvider.GenerateOtpAsync</c>).
+    /// </summary>
+    protected async Task<string> GetIssuedOtpAsync(string phone, OtpPurpose purpose)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var provider = scope.ServiceProvider.GetRequiredService<IOtpCodeProvider>();
+
+        var otp = await provider.GetOtpAsync(phone, purpose);
+        Assert.NotNull(otp);
+
+        return otp!.Code;
     }
 }

--- a/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/PasswordResetTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/AuthEndpoints/PasswordResetTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Ombor.Contracts.Responses.Auth;
 using Ombor.Domain.Entities;
+using Ombor.Domain.Enums;
 using Ombor.Tests.Integration.Helpers;
 using Xunit.Abstractions;
 
@@ -13,7 +14,6 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
 {
     private const string OldPassword = "OldPassw0rd";
     private const string NewPassword = "NewPassw0rd";
-    private const string DemoCode = "1234"; // the OtpCodeProvider dev stub issues this for every OTP
 
     [Fact]
     public async Task FullFlow_ResetsPassword_AndLetsUserLogInWithTheNewPassword()
@@ -21,11 +21,12 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
         // Arrange — an existing user with a known old password.
         var (_, phone) = await SeedUserAsync(OldPassword);
 
-        // Act — request a reset, then reset with the demo code.
+        // Act — request a reset, then reset with the code the server actually issued.
         await _client.PostAsync<ForgotPasswordResponse>("auth/forgot-password", new { phoneNumber = phone }, HttpStatusCode.OK);
+        var code = await GetIssuedOtpAsync(phone, OtpPurpose.PasswordReset);
         var reset = await _client.PostAsync<ResetPasswordResponse>(
             "auth/reset-password",
-            new { phoneNumber = phone, code = DemoCode, newPassword = NewPassword, confirmPassword = NewPassword },
+            new { phoneNumber = phone, code, newPassword = NewPassword, confirmPassword = NewPassword },
             HttpStatusCode.OK);
 
         // Assert — reset succeeded and the user can now log in with the NEW password (proving the hash changed).
@@ -51,11 +52,12 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
     {
         var (_, phone) = await SeedUserAsync(OldPassword);
         await _client.PostAsync<ForgotPasswordResponse>("auth/forgot-password", new { phoneNumber = phone }, HttpStatusCode.OK);
+        var code = await GetIssuedOtpAsync(phone, OtpPurpose.PasswordReset);
 
         var ok = await _client.PostAsync<VerifyResetCodeResponse>(
-            "auth/verify-reset-code", new { phoneNumber = phone, code = DemoCode }, HttpStatusCode.OK);
+            "auth/verify-reset-code", new { phoneNumber = phone, code }, HttpStatusCode.OK);
         var wrong = await _client.PostAsync<VerifyResetCodeResponse>(
-            "auth/verify-reset-code", new { phoneNumber = phone, code = "9999" }, HttpStatusCode.OK);
+            "auth/verify-reset-code", new { phoneNumber = phone, code = WrongCodeFor(code) }, HttpStatusCode.OK);
 
         Assert.True(ok.Success);
         Assert.False(wrong.Success);
@@ -68,10 +70,12 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
     {
         var (_, phone) = await SeedUserAsync(OldPassword);
         await _client.PostAsync<ForgotPasswordResponse>("auth/forgot-password", new { phoneNumber = phone }, HttpStatusCode.OK);
+        var code = await GetIssuedOtpAsync(phone, OtpPurpose.PasswordReset);
 
+        // Password validation fires before the code check, so the (valid) code never gets that far — still a 400.
         var problem = await _client.PostAsync<ValidationProblemDetails>(
             "auth/reset-password",
-            new { phoneNumber = phone, code = DemoCode, newPassword, confirmPassword },
+            new { phoneNumber = phone, code, newPassword, confirmPassword },
             HttpStatusCode.BadRequest);
 
         Assert.NotNull(problem);
@@ -82,10 +86,11 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
     {
         var (_, phone) = await SeedUserAsync(OldPassword);
         await _client.PostAsync<ForgotPasswordResponse>("auth/forgot-password", new { phoneNumber = phone }, HttpStatusCode.OK);
+        var code = await GetIssuedOtpAsync(phone, OtpPurpose.PasswordReset);
 
         var reset = await _client.PostAsync<ResetPasswordResponse>(
             "auth/reset-password",
-            new { phoneNumber = phone, code = "9999", newPassword = NewPassword, confirmPassword = NewPassword },
+            new { phoneNumber = phone, code = WrongCodeFor(code), newPassword = NewPassword, confirmPassword = NewPassword },
             HttpStatusCode.OK);
 
         Assert.False(reset.Success);
@@ -109,13 +114,18 @@ public sealed class PasswordResetTests(TestingWebApplicationFactory factory, ITe
 
         // Act
         await _client.PostAsync<ForgotPasswordResponse>("auth/forgot-password", new { phoneNumber = phone }, HttpStatusCode.OK);
+        var code = await GetIssuedOtpAsync(phone, OtpPurpose.PasswordReset);
         await _client.PostAsync<ResetPasswordResponse>(
             "auth/reset-password",
-            new { phoneNumber = phone, code = DemoCode, newPassword = NewPassword, confirmPassword = NewPassword },
+            new { phoneNumber = phone, code, newPassword = NewPassword, confirmPassword = NewPassword },
             HttpStatusCode.OK);
 
         // Assert — the pre-existing session was revoked.
         var refreshed = await _context.RefreshTokens.AsNoTracking().FirstAsync(t => t.Id == token.Id);
         Assert.True(refreshed.IsRevoked);
     }
+
+    // A 4-digit code guaranteed to differ from the issued one (the issued code is random, so a fixed literal
+    // could, rarely, collide with it).
+    private static string WrongCodeFor(string code) => code == "0000" ? "1111" : "0000";
 }


### PR DESCRIPTION
Fixes the 3 long-standing `PasswordResetTests` failures on `redesign/issue-fixes` (the known baseline). Off `redesign/issue-fixes`.

## Root cause
`OtpCodeProvider.GenerateOtpAsync` mints a **random** code (`RandomNumberGenerator.GetInt32(1000, 9999)`) — `var code = "1234"` is commented out. The tests hardcoded the old `"1234"` dev stub, so the 3 flows that need a *correct* code (`FullFlow`, `VerifyResetCode` ok-case, `ResetPassword_RevokesTheUsersExistingSessions`) failed.

## Fix (test-only — no production code touched)
- `AuthTestsBase.GetIssuedOtpAsync(phone, purpose)` reads the code the server actually issued from the shared in-memory OTP store (`IOtpCodeProvider`, resolved via `_factory.Services` — the same DI pattern `SeedUserAsync` already uses).
- The reset tests now fetch the real code after `forgot-password`. Wrong-code negatives use a code guaranteed to differ from the (random) issued one, removing a latent 1/9000 flake.

The random OTP is the intended production behavior, so the tests adapt to it rather than the other way around.

**Result:** full integration suite now green with **zero failures (259/259)** — the `PasswordResetTests` baseline is eliminated.

> Note (not changed here): the `// TODO: Uncomment ... when released to production!` comment above the commented-out `var code = "1234"` in `OtpCodeProvider` reads backwards (the active random generator *is* the production path) — a trivial optional cleanup, left out to keep this branch test-only.
