### PR TITLE
Echo settled-transaction notes + attachments on the payment response

### DIFF
--- a/src/Ombor.Application/Services/PaymentService.cs
+++ b/src/Ombor.Application/Services/PaymentService.cs
@@ -354,7 +354,22 @@ internal sealed class PaymentService(
                 a.FileName,
                 a.ContentType,
                 a.SizeBytes,
-                a.Url)).ToArray());
+                a.Url)).ToArray(),
+            // Echo the settled transaction's note (the single one this payment settles; first if several).
+            p.Allocations
+                .Where(a => a.Type == PaymentAllocationType.TransactionSettlement && a.Transaction != null)
+                .Select(a => a.Transaction!.Notes)
+                .FirstOrDefault(),
+            // Echo the settled transaction(s)' attachments (union), stored on the transaction — not duplicated.
+            p.Allocations
+                .Where(a => a.Type == PaymentAllocationType.TransactionSettlement && a.Transaction != null)
+                .SelectMany(a => a.Transaction!.Attachments)
+                .Select(ta => new PaymentAttachmentDto(
+                    ta.Id,
+                    ta.FileName,
+                    ta.ContentType,
+                    ta.SizeBytes,
+                    ta.Url)).ToArray());
 
     public async Task<PaymentRecordDto> CreateAsync(CreatePayrollRequest request)
     {

--- a/src/Ombor.Contracts/Responses/Payment/PaymentRecordDto.cs
+++ b/src/Ombor.Contracts/Responses/Payment/PaymentRecordDto.cs
@@ -4,6 +4,15 @@ namespace Ombor.Contracts.Responses.Payment;
 /// A payment in the source/allocation model (rules 8-14). <see cref="Sources"/> is where the
 /// money came from; <see cref="Allocations"/> is what it settled. All money figures are server-computed.
 /// </summary>
+/// <param name="TransactionNotes">
+/// Echoed read-only from the transaction(s) this payment settles: the note captured when a transaction and
+/// its payment are created together belongs to either — we can't tell upfront — so it is surfaced on both.
+/// The single settled transaction's note (the first, if the payment settles several); null when none.
+/// </param>
+/// <param name="TransactionAttachments">
+/// Echoed read-only: the attachments of the transaction(s) this payment settles (union when it settles more
+/// than one); empty when none. The files are stored on the transaction — not duplicated onto the payment.
+/// </param>
 public sealed record PaymentRecordDto(
     int Id,
     string? Number,
@@ -27,7 +36,9 @@ public sealed record PaymentRecordDto(
     string? CreatedBy,
     PaymentSourceDto[] Sources,
     PaymentAllocationEntryDto[] Allocations,
-    PaymentAttachmentDto[] Attachments);
+    PaymentAttachmentDto[] Attachments,
+    string? TransactionNotes,
+    PaymentAttachmentDto[] TransactionAttachments);
 
 /// <summary>
 /// A file uploaded with a payment. Raw values only — the client derives the icon from

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/PaymentTransactionEchoTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/PaymentTransactionEchoTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Ombor.Contracts.Enums;
+using Ombor.Contracts.Requests.Payment;
+using Ombor.Contracts.Requests.Transaction;
+using Ombor.Contracts.Responses.Payment;
+using Ombor.Contracts.Responses.Transaction;
+using Ombor.Tests.Common.Extensions;
+using Ombor.Tests.Integration.Helpers;
+using Xunit.Abstractions;
+
+namespace Ombor.Tests.Integration.Endpoints.Transactions;
+
+public sealed class PaymentTransactionEchoTests(TestingWebApplicationFactory factory, ITestOutputHelper output)
+    : TransactionsTestsBase(factory, output)
+{
+    [Fact]
+    public async Task Payment_ShouldEchoSettledTransactionNotesAndAttachments()
+    {
+        // Arrange — a fully-paid Sale carrying a note + one file; the inline payment settles it.
+        var partnerId = await CreatePartnerAsync();
+        var walletId = await CreateWalletAsync();
+        var warehouseId = await CreateWarehouseAsync();
+        var productId = await CreateProductAsync();
+        await SeedStockAsync(warehouseId, productId, quantity: 100);
+
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        var request = new CreateTransactionRequest(
+            PartnerId: partnerId,
+            Type: TransactionType.Sale,
+            Notes: "Delivered to front desk.",
+            Lines: [new CreateTransactionLine(productId, UnitPrice: 5_000m, Discount: 0m, DiscountType.Percentage, Quantity: 1)],
+            WalletId: walletId,
+            PaidAmount: 5_000m,
+            Settlements: null,
+            Overpayment: OverpaymentHandling.Change,
+            Attachments: [BuildFile("receipt.jpg", "image/jpeg", content)],
+            WarehouseId: warehouseId);
+
+        var created = await _client.PostAsync<TransactionDto>(GetUrl(), request.ToMultipartFormData(), HttpStatusCode.Created);
+
+        // The inline payment that settled this transaction.
+        var paymentId = await _context.PaymentAllocations.AsNoTracking()
+            .Where(a => a.TransactionId == created.Id)
+            .Select(a => a.PaymentId)
+            .FirstAsync();
+
+        // Act
+        var payment = await _client.GetAsync<PaymentRecordDto>($"payments/{paymentId}");
+
+        // Assert — the settled transaction's note + attachment are echoed onto the payment (read-side, not duplicated).
+        Assert.Equal("Delivered to front desk.", payment.TransactionNotes);
+        var echoed = Assert.Single(payment.TransactionAttachments);
+        Assert.Equal("receipt.jpg", echoed.Name);
+        Assert.Equal("image/jpeg", echoed.ContentType);
+        Assert.Equal(content.Length, echoed.SizeBytes);
+        Assert.False(string.IsNullOrWhiteSpace(echoed.Url));
+
+        // The payment's OWN attachments stay separate — nothing was uploaded to the payment itself.
+        Assert.Empty(payment.Attachments);
+    }
+
+    [Fact]
+    public async Task Payment_ShouldLeaveEchoEmpty_WhenItSettlesNoTransaction()
+    {
+        // Arrange — a standalone deposit that settles nothing.
+        var partnerId = await CreatePartnerAsync();
+        var walletId = await CreateWalletAsync();
+
+        var deposit = new CreatePaymentRecordRequest(
+            PaymentType.Deposit, PaymentDirection.Income, partnerId, null, walletId,
+            Amount: 1_000m, Description: null, Period: null, Settlements: []);
+        var payment = await _client.PostAsync<PaymentRecordDto>("payments", deposit.ToMultipartFormData());
+
+        // Act
+        var fetched = await _client.GetAsync<PaymentRecordDto>($"payments/{payment.Id}");
+
+        // Assert — no settled transaction, so nothing to echo.
+        Assert.Null(fetched.TransactionNotes);
+        Assert.Empty(fetched.TransactionAttachments);
+    }
+
+    private static FormFile BuildFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+
+        return new FormFile(stream, 0, content.Length, "Attachments", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType,
+        };
+    }
+}


### PR DESCRIPTION
Echoes the settled transaction's **notes + attachments** onto the payment response (read-side, no duplication). Off `redesign/issue-fixes`.

**Why:** when a transaction and its payment are created together, the single note/attachment field is stored on the transaction — but it may really belong to the payment, and we can't know upfront. So the payment now surfaces the transaction's note + files too.

- `PaymentRecordDto` gains `transactionNotes` (string?) + `transactionAttachments[]`, projected in `ToRecordExpression` from the transaction(s) the payment settles (`TransactionSettlement` allocations): notes = the single settled transaction's note (first if it settles several); attachments = union across settled transactions. Files remain stored on the transaction — **not duplicated**.
- Contract doc `transactions-payments.md` updated (in `Ombor.Docs`).

**Tests:** an inline payment echoes the sale's note + uploaded file; a standalone deposit that settles nothing echoes empty. Full integration suite green (**273/273**).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment records now display notes from their settled transactions.
  * Payment records now include attachments from all associated settled transactions.
  * Payments that do not settle a transaction continue to show no transaction notes or attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->