### PR TITLE
Serve walletId on payment settlement + partner-ledger rows (XC-8)

### DIFF
--- a/src/Ombor.Application/Services/PartnerService.cs
+++ b/src/Ombor.Application/Services/PartnerService.cs
@@ -124,6 +124,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
                 p.Number,
                 p.Type,
                 p.Direction,
+                p.WalletId,
                 WalletName = p.Wallet != null ? p.Wallet.Name : null,
                 WalletType = p.Wallet != null ? p.Wallet.Type.ToString() : null,
                 // Only settling allocations move the balance; ChangeReturn is a memo (rule 10).
@@ -145,7 +146,8 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
                 null,
                 null,
                 null, // WalletName — opening has no wallet
-                null),
+                null, // WalletType
+                null), // WalletId
         };
 
         foreach (var t in transactions)
@@ -165,7 +167,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
 
             // Transactions aren't tied to a single wallet (settled across zero-to-many payments), so no wallet here.
             // Reference carries the bare document Number (null on synthetic seed rows), mirroring payments below.
-            events.Add(new(t.Id, type, t.DateUtc, sign * t.TotalDue, t.Id, t.Number?.ToString(), t.ItemCount, status, null, null));
+            events.Add(new(t.Id, type, t.DateUtc, sign * t.TotalDue, t.Id, t.Number?.ToString(), t.ItemCount, status, null, null, null));
         }
 
         foreach (var p in payments)
@@ -179,7 +181,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
                 _ => "payment",
             };
 
-            events.Add(new(p.Id, type, p.DateUtc, sign * p.Settling, p.Id, p.Number?.ToString(), null, "done", p.WalletName, p.WalletType));
+            events.Add(new(p.Id, type, p.DateUtc, sign * p.Settling, p.Id, p.Number?.ToString(), null, "done", p.WalletName, p.WalletType, p.WalletId));
         }
 
         // Fold the running balance oldest→newest (final value reconciles to PartnerBalance.Total), then newest-first.
@@ -190,7 +192,7 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
             .Select(e =>
             {
                 running += e.Delta;
-                return new PartnerLedgerEntryDto(e.Id, e.Type, e.Date, e.Delta, running, e.SourceId, e.Reference, e.ItemCount, e.Status, e.WalletName, e.WalletType);
+                return new PartnerLedgerEntryDto(e.Id, e.Type, e.Date, e.Delta, running, e.SourceId, e.Reference, e.ItemCount, e.Status, e.WalletName, e.WalletType, e.WalletId);
             })
             .ToList();
 
@@ -260,5 +262,6 @@ internal sealed class PartnerService(IApplicationDbContext context, IRequestVali
         int? ItemCount,
         string? Status,
         string? WalletName,
-        string? WalletType);
+        string? WalletType,
+        int? WalletId);
 }

--- a/src/Ombor.Application/Services/PaymentService.cs
+++ b/src/Ombor.Application/Services/PaymentService.cs
@@ -431,6 +431,7 @@ internal sealed class PaymentService(
                 a.PaymentId,
                 a.Amount,
                 a.Payment.Number.ToString(),
+                a.Payment.WalletId,
                 a.Payment.Wallet != null ? a.Payment.Wallet.Name : null,
                 a.Payment.Wallet != null ? a.Payment.Wallet.Type.ToString() : null,
                 a.Payment.Notes,

--- a/src/Ombor.Application/Services/TransactionService.cs
+++ b/src/Ombor.Application/Services/TransactionService.cs
@@ -132,6 +132,7 @@ internal sealed class TransactionService(
                         a.PaymentId,
                         a.Amount,
                         a.Payment.Number.ToString(),
+                        a.Payment.WalletId,
                         a.Payment.Wallet != null ? a.Payment.Wallet.Name : null,
                         a.Payment.Wallet != null ? a.Payment.Wallet.Type.ToString() : null,
                         a.Payment.Notes, a.Payment.DateUtc)).ToArray(),

--- a/src/Ombor.Contracts/Responses/Partner/PartnerLedgerEntryDto.cs
+++ b/src/Ombor.Contracts/Responses/Partner/PartnerLedgerEntryDto.cs
@@ -19,6 +19,7 @@ namespace Ombor.Contracts.Responses.Partner;
 /// <param name="Status">Settlement status for transaction events (paid, partial, unpaid) or "done".</param>
 /// <param name="WalletName">The wallet the money moved through, for payment events (payment, deposit, withdraw); null otherwise.</param>
 /// <param name="WalletType">The wallet's type (e.g. Cash, Card), for payment events; null otherwise.</param>
+/// <param name="WalletId">The wallet's id (deep-link target), for payment events; null otherwise.</param>
 public sealed record PartnerLedgerEntryDto(
     int Id,
     string Type,
@@ -30,4 +31,5 @@ public sealed record PartnerLedgerEntryDto(
     int? ItemCount,
     string? Status,
     string? WalletName,
-    string? WalletType);
+    string? WalletType,
+    int? WalletId);

--- a/src/Ombor.Contracts/Responses/Payment/TransactionPaymentDto.cs
+++ b/src/Ombor.Contracts/Responses/Payment/TransactionPaymentDto.cs
@@ -5,6 +5,7 @@ namespace Ombor.Contracts.Responses.Payment;
 /// <param name="TransactionId">The transaction settled.</param>
 /// <param name="Amount">The amount applied to the transaction.</param>
 /// <param name="PaymentNumber">The payment's human-facing document number, sequential per organization.</param>
+/// <param name="WalletId">The wallet the money moved through (deep-link target); null when the payment has no wallet.</param>
 /// <param name="WalletName">The wallet the money moved through.</param>
 /// <param name="WalletType">The wallet type (Cash/Card/Bank).</param>
 /// <param name="Notes">Optional payment note.</param>
@@ -15,6 +16,7 @@ public sealed record TransactionPaymentDto(
     int PaymentId,
     decimal Amount,
     string? PaymentNumber,
+    int? WalletId,
     string? WalletName,
     string? WalletType,
     string? Notes,

--- a/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerLedgerTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/PartnerEndpoints/PartnerLedgerTests.cs
@@ -42,6 +42,8 @@ public sealed class PartnerLedgerTests(TestingWebApplicationFactory factory, ITe
         Assert.Equal(-4_000m, payment.Delta); // an Income payment reduces what the partner owes
         Assert.Equal(walletName, payment.WalletName); // payment rows carry the wallet for the «Платежи» tab column
         Assert.Equal("Cash", payment.WalletType);
+        Assert.NotNull(payment.WalletId); // XC-8: the FE can now deep-link the wallet
+        Assert.Null(sale.WalletId);       // transactions aren't tied to a single wallet, so no wallet id
 
         Assert.Null(ledger.Single(e => e.Type == "opening").WalletName);
     }

--- a/tests/Ombor.Tests.Integration/Endpoints/Transactions/GetTransactionByIdTests.cs
+++ b/tests/Ombor.Tests.Integration/Endpoints/Transactions/GetTransactionByIdTests.cs
@@ -58,6 +58,7 @@ public sealed class GetTransactionByIdTests(TestingWebApplicationFactory factory
         Assert.Equal(4_000m, payment.Amount);
         Assert.Equal(walletName, payment.WalletName);
         Assert.Equal("Cash", payment.WalletType);
+        Assert.NotNull(payment.WalletId); // XC-8: the wallet id is served so the FE can deep-link it
 
         // Assert — audit card (author display name) + note
         Assert.Equal($"{AuthorFirstName} {AuthorLastName}", detail.CreatedBy);


### PR DESCRIPTION
Closes the last backend half of **XC-8** — serves `walletId` on partner-payment rows so the FE can deep-link the wallet. Off `redesign/issue-fixes`.

The FE could render the wallet *name* on those rows but not link it: `TransactionPaymentDto` and `PartnerLedgerEntryDto` exposed `walletName`/`walletType` but no id.

- Adds `int? WalletId` to both DTOs, populated from the payment's `WalletId` in their projections (the wallet is already loaded — one-line addition each). Read-side only, no migration.
- Assertions added to the partner-ledger and transaction-detail tests.

Matches the contract already documented in `partners-debts-dashboard.md` + `transactions-payments.md`. Full integration suite green (**273/273**).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment and ledger entries now include wallet identifiers, enabling direct navigation to the associated wallet.
  * Transaction details now expose wallet identifiers for settling payments.
  * Non-wallet transaction entries correctly indicate that no wallet is associated.

* **Tests**
  * Added coverage verifying wallet identifiers are included for payment records and omitted from transaction-only entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->